### PR TITLE
fix: Adds check to use countries_bbox.json when name of location matches with country

### DIFF
--- a/geocoder_module/geocoder.py
+++ b/geocoder_module/geocoder.py
@@ -146,10 +146,22 @@ class Geocoder:
             if country and features["properties"]["country"] != country:
                 continue
 
+            # If a country is provided, then retrieve the bounding box from
+            # countries_bbox.json
+            if (
+                features["properties"]["name"].lower()
+                == features["properties"]["country"].lower()
+            ):
+                location["bounding_box"] = self.country_bbox[
+                    features["properties"]["country"].lower()
+                ]
+            else:
+                location["bounding_box"] = features["properties"]["extent"]
+
             location["name"] = features["properties"]["name"]
-            location["bounding_box"] = features["properties"]["extent"]
             location["country"] = features["properties"]["country"]
             location["coordinates"] = features["geometry"]["coordinates"]
+            # Add results
             results.append(location)
 
             # the first results is the always the best matching one


### PR DESCRIPTION
## Why?
This PR adds a check for using countries bounding boxes coordinates from our curated file when the result is a country.

## What?
- Adds check on get_location_info function to retrieve coordinates from `countries_bbox` object.

## Anything in particular you'd like to highlight to reviewers?
I need to add unit tests here. I saw this [PR](https://github.com/lifebit-ai/nlp-geocode-module/pull/8) so wasn't sure how to proceed