### PR TITLE
Add Geonames service and location validation steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/__pycache__/**
 .vscode
+*.egg-info
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains the code for the Geocoder module, that provides coordin
 
 The parameters for the config file are:
 
+- `geonames_api_endpoint`: 
 - `url_api_endpoint`: api endpoint for the `Photon` geocoder.
 - `url_reverse_endpoint`: api endpoint for the `Photon` decoder (to get location from coordinates, not implemented for future use).
 - `lang`: parameter to specify the language of the returned results, default is `"en"`
@@ -18,6 +19,7 @@ The parameters for the config file are:
 The required environment variable is for your photon geocoder server:
 
 - PHOTON_SERVER (Eg: `export PHOTON_SERVER=http://<ip-address>:<port number>`)
+- GEONAMES_SERVER (Eg: `export GEONAMES_SERVER=http://<ip-address>:<port number>`)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ The parameters for the config file are:
 - `lang`: parameter to specify the language of the returned results, default is `"en"`
 - `osm_keys`: list of filters on the geocoder results, based on Open Stree Map features https://wiki.openstreetmap.org/wiki/Map_features. Default is `place`
 
-### Installing module
+### Running the unit tests
 
-Remember to install the module, before running tests or you won't be able to test changes. Use `pip3 install -e .` to ensure that happens.
+Remember to install the module, before running tests or you won't be able to test your changes as the `pytest` command will run against the package. The `pip3 install -e .` will ensure this happens.
+
+```shell
+export PHOTON_SERVER=test 	# Set dummy environment variable when running tests
+export GEONAMES_SERVER=test # Set dummy environment variable when running tests
+pip3 install -e . && pytest -vv	# Run the tests while updating the package with latest changes
+```
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ This repository contains the code for the Geocoder module, that provides coordin
 
 The parameters for the config file are:
 
-- `geonames_api_endpoint`: 
+- `geonames_api_endpoint`: api endpoint for the `Geonames` location service.
 - `url_api_endpoint`: api endpoint for the `Photon` geocoder.
 - `url_reverse_endpoint`: api endpoint for the `Photon` decoder (to get location from coordinates, not implemented for future use).
 - `lang`: parameter to specify the language of the returned results, default is `"en"`
 - `osm_keys`: list of filters on the geocoder results, based on Open Stree Map features https://wiki.openstreetmap.org/wiki/Map_features. Default is `place`
+
+### Installing module
+
+Remember to install the module, before running tests or you won't be able to test changes. Use `pip3 install -e .` to ensure that happens.
 
 ### Environment Variables
 

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -2,4 +2,7 @@ run-unit-tests:
   build:
     context: .
     dockerfile: tests/Dockerfile
+  environment:
+    - PHOTON_SERVER=test
+    - GEONAMES_SERVER=test
   cached: true

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,0 +1,5 @@
+run-unit-tests:
+  build:
+    context: .
+    dockerfile: tests/Dockerfile
+  cached: true

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,0 +1,6 @@
+- name: Run unit tests
+  type: parallel
+  steps:
+    - name: tests
+      service: run-unit-tests
+      command: pytest -vv

--- a/geocoder_module/config.yaml
+++ b/geocoder_module/config.yaml
@@ -1,3 +1,4 @@
+geonames_api: "http://<URL>:<PORT>/locations?"
 url_api: "http://34.105.131.180:2322/api?"
 url_reverse: "http://34.105.131.180:2322/reverse?"
 lang: "en"

--- a/geocoder_module/config.yaml
+++ b/geocoder_module/config.yaml
@@ -1,4 +1,4 @@
-geonames_api: "http://<URL>:<PORT>/locations?"
+geonames_api: "http://34.105.131.180:8000>/locations?"
 url_api: "http://34.105.131.180:2322/api?"
 url_reverse: "http://34.105.131.180:2322/reverse?"
 lang: "en"

--- a/geocoder_module/config.yaml
+++ b/geocoder_module/config.yaml
@@ -1,4 +1,4 @@
-geonames_api: "http://34.105.131.180:8000>/locations?"
+geonames_api: "http://34.105.131.180:8000/locations?"
 url_api: "http://34.105.131.180:2322/api?"
 url_reverse: "http://34.105.131.180:2322/reverse?"
 lang: "en"

--- a/geocoder_module/geocoder.py
+++ b/geocoder_module/geocoder.py
@@ -122,7 +122,6 @@ class Geocoder:
                 params={"country": country.lower(), "local_location": location.lower()},
             )
             response = response.json()
-            print(f"Geonames response : {response}")
         except Exception as e:
             logging.error("Error in querying location {} ".format(location))
             logging.error(e)
@@ -175,7 +174,6 @@ class Geocoder:
                 },
             )
             response = response.json()
-            print(f"Geocoder response : {response}")
         except Exception as e:
             logging.error("Error in querying location {} ".format(location))
             logging.error(e)

--- a/geocoder_module/geocoder.py
+++ b/geocoder_module/geocoder.py
@@ -310,6 +310,7 @@ class Geocoder:
         """
 
         mapping_countries = {}
+        only_countries = {}
 
         countries = []
 
@@ -320,12 +321,23 @@ class Geocoder:
                     continue
                 countries.append(location["country"])
                 mapping_countries[location["name"]] = location["country"]
+                if location["name"] == location["country"]:
+                    if location["country"] in only_countries:
+                        only_countries[location["country"]] += 1
+                    else:
+                        only_countries[location["country"]] = 1
+
             else:
                 for l in location:
                     if l["country"] == []:
                         continue
                     countries.append(l["country"])
                     mapping_countries[l["name"]] = l["country"]
+                    if l["name"] == l["country"]:
+                        if l["country"] in only_countries:
+                            only_countries[l["country"]] += 1
+                        else:
+                            only_countries[l["country"]] = 1
 
         # extract the candidate reference countries
         if not top_countries:
@@ -340,27 +352,60 @@ class Geocoder:
             )
             return locations
 
-        for name, country in mapping_countries.items():
-            # the location is a country no need to check it
-            if name == country:
-                continue
-            # iterating from the most frequent country
-            for reference_country in majority:
-                if reference_country[1] == 1:
-                    break
-                reference_country = reference_country[0]
-                if country != reference_country:
-                    new_location = self.get_location_info(
-                        name, country=reference_country, best_matching=True
-                    )
-
-                    # check if the refernce country can be used for this location
-                    if new_location != []:
-                        mapping_countries[name] = new_location[0]["country"]
+        ## Edge case 1: If there are few locations and 1 is a country
+        ## We assume that the few locations belong to that country, so that country is the new country location
+        if len(only_countries) == 1:
+            new_country = list(only_countries.keys())[0]
+            for name, country in mapping_countries.items():
+                # the location is a country no need to check it
+                if name == country:
+                    continue
+                # iterating from the most frequent country
+                for reference_country in majority:
+                    if reference_country[1] == 1:
                         break
-                else:
-                    break
+                    reference_country = new_country
+                    if country != reference_country:
+                        new_location = self.get_location_info(
+                            name, country=reference_country, best_matching=True
+                        )
+                        # check if the refernce country can be used for this location
+                        if new_location != []:
+                            mapping_countries[name] = new_location[0]["country"]
+                            break
+                    else:
+                        break
 
+        ## Edge case 2: If there are references to multiple countries including or not local locations
+        ## We assume no majority can be reached and local locations will be included
+        ## if they match with one of the countries, others will be discarded
+        elif len(only_countries) > 1:
+            logging.warning(
+                f"Found {len(only_countries)} references to countries, locations not matching one of those countries will be discarded"
+            )
+
+        ## General case: Multiple locations with a clear majority
+        else:
+            for name, country in mapping_countries.items():
+                # the location is a country no need to check it
+                if name == country:
+                    continue
+                # iterating from the most frequent country
+                for reference_country in majority:
+                    if reference_country[1] == 1:
+                        break
+                    reference_country = reference_country[0]
+                    if country != reference_country:
+                        new_location = self.get_location_info(
+                            name, country=reference_country, best_matching=True
+                        )
+                        # check if the refernce country can be used for this location
+                        if new_location != []:
+                            mapping_countries[name] = new_location[0]["country"]
+                            break
+                    else:
+                        break
+        # Update new locations
         new_locations = []
 
         for location in locations:
@@ -370,15 +415,20 @@ class Geocoder:
             new_country = mapping_countries[location["name"]]
             new_location = None
             if new_country != location["country"]:
+                logging.info(f'Changing {location["country"]} to {new_country}')
                 new_location = self.get_location_info(
                     location["name"],
                     country=new_country,
                     best_matching=True,
                 )
             if new_location:
-                new_locations.append(new_location)
-            else:
+                new_locations.append(new_location[0])
+            elif location["country"] in only_countries:
                 new_locations.append(location)
+            elif not only_countries:
+                new_locations.append(location)
+            else:
+                new_locations.append({})
 
         return new_locations
 

--- a/geocoder_module/geocoder.py
+++ b/geocoder_module/geocoder.py
@@ -133,7 +133,7 @@ class Geocoder:
             location["name"] = response["name"]
             location["country"] = response["country"]
             location["coordinates"] = [response["longitude"], response["latitude"]]
-            if location.lower() == country.lower():
+            if location["name"].lower() == country.lower():
                 try:
                     location["bounding_box"] = self.country_bbox[country.lower()]
                 except:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.25.1
+pytest-asyncio==0.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.25.1
-pytest-asyncio==0.15.1
+pytest==6.1.1

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,9 +5,6 @@ WORKDIR /usr/src/app
 # set python path to include working directory
 ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app"
 
-ENV PHOTON_SERVER=test
-ENV GEONAMES_SERVER=test
-
 # copy the dependencies file to the working directory
 COPY requirements.txt .
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -11,7 +11,7 @@ COPY requirements.txt .
 # install dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
-RUN pip install -e .
-
 # copy the content of the local src directory to the working directory
 COPY . .
+
+RUN pip install .

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /usr/src/app
 # set python path to include working directory
 ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app"
 
+ENV PHOTON_SERVER=test
+ENV GEONAMES_SERVER=test
+
 # copy the dependencies file to the working directory
 COPY requirements.txt .
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.9
+
+WORKDIR /usr/src/app
+
+# set python path to include working directory
+ENV PYTHONPATH="${PYTHONPATH}:/usr/src/app"
+
+# copy the dependencies file to the working directory
+COPY requirements.txt .
+
+# install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+RUN pip install -e .
+
+# copy the content of the local src directory to the working directory
+COPY . .

--- a/tests/test_get_location.py
+++ b/tests/test_get_location.py
@@ -7,7 +7,7 @@ geocoder = Geocoder()
 
 
 @patch("requests.get")
-def test_get_geocoder_info_returns_right_location_when_found_by_geocoder(
+def test_get_geocoder_info_returns_a_location_when_queried(
     mock_get,
 ):
     expected_get_geocoder_api_output = {
@@ -71,7 +71,34 @@ def test_get_geocoder_info_returns_right_location_when_found_by_geocoder(
             ],
         }
     ]
-    response = geocoder.get_location_info("sydney")
+    response = geocoder._get_geocode_info("sydney")
+
+    assert mock_get.called
+    assert response == expected_output
+
+
+@patch("requests.get")
+def test_get_geonames_info_returns_right_location_when_queried(
+    mock_get,
+):
+    expected_get_geonames_api_output = {
+        "name": "Sydney",
+        "latitude": "-33.86778",
+        "longitude": "151.20844",
+        "country": "Australia",
+        "continent": "Oceania",
+    }
+    # Generate expected output from both get requests
+    mock_get.return_value.json.return_value = expected_get_geonames_api_output
+
+    expected_output = [
+        {
+            "name": "Sydney",
+            "coordinates": ["151.20844", "-33.86778"],
+            "country": "Australia",
+        }
+    ]
+    response = geocoder._get_geonames_info("sydney", "australia")
 
     assert mock_get.called
     assert response == expected_output
@@ -102,35 +129,15 @@ def test_get_location_info_returns_right_location_when_found_by_geocoder_and_geo
                     "type": "city",
                 },
             },
-            {
-                "geometry": {"coordinates": [151.210047, -33.8679574], "type": "Point"},
-                "type": "Feature",
-                "properties": {
-                    "osm_id": 5729534,
-                    "osm_type": "R",
-                    "extent": [151.1970047, -33.8561096, 151.223011, -33.8797564],
-                    "country": "Australia",
-                    "osm_key": "place",
-                    "city": "Council of the City of Sydney",
-                    "countrycode": "AU",
-                    "osm_value": "suburb",
-                    "postcode": "2000",
-                    "name": "Sydney",
-                    "state": "New South Wales",
-                    "type": "district",
-                },
-            },
         ]
     }
-    expected_get_geonames_api_output = [
-        {
-            "name": "Sydney",
-            "latitude": "-33.86778",
-            "longitude": "151.20844",
-            "country": "Australia",
-            "continent": "Oceania",
-        }
-    ]
+    expected_get_geonames_api_output = {
+        "name": "Sydney",
+        "latitude": "-33.86778",
+        "longitude": "151.20844",
+        "country": "Australia",
+        "continent": "Oceania",
+    }
     # Generate expected output from both get requests
     mock_get.return_value.json.return_value = "test"
     mock_get.return_value.json.side_effect = [
@@ -185,7 +192,7 @@ def test_get_location_info_returns_empty_list_when_location_found_by_geocoder_ca
             }
         ]
     }
-    expected_get_geonames_api_output_2 = [{}]
+    expected_get_geonames_api_output_2 = {}
     # Generate expected output from both get requests
     mock_get.return_value.json.side_effect = [
         expected_get_geocoder_api_output_2,

--- a/tests/test_get_location.py
+++ b/tests/test_get_location.py
@@ -6,9 +6,8 @@ from geocoder_module.geocoder import Geocoder
 geocoder = Geocoder()
 
 
-@pytest.mark.asyncio
 @patch("requests.get")
-async def test_get_geocoder_info_returns_right_location_when_found_by_geocoder(
+def test_get_geocoder_info_returns_right_location_when_found_by_geocoder(
     mock_get,
 ):
     expected_get_geocoder_api_output = {
@@ -78,9 +77,8 @@ async def test_get_geocoder_info_returns_right_location_when_found_by_geocoder(
     assert response == expected_output
 
 
-@pytest.mark.asyncio
 @patch("requests.get")
-async def test_get_location_info_returns_right_location_when_found_by_geocoder_and_geonames(
+def test_get_location_info_returns_right_location_when_found_by_geocoder_and_geonames(
     mock_get,
 ):
     expected_get_geocoder_api_output = {
@@ -161,9 +159,8 @@ async def test_get_location_info_returns_right_location_when_found_by_geocoder_a
     assert response == expected_output
 
 
-@pytest.mark.asyncio
 @patch("requests.get")
-async def test_get_location_info_returns_empty_list_when_location_found_by_geocoder_cant_be_validated_by_geonames(
+def test_get_location_info_returns_empty_list_when_location_found_by_geocoder_cant_be_validated_by_geonames(
     mock_get,
 ):
     expected_get_geocoder_api_output_2 = {

--- a/tests/test_get_location.py
+++ b/tests/test_get_location.py
@@ -1,0 +1,201 @@
+from unittest.mock import Mock, patch
+import pytest
+
+from geocoder_module.geocoder import Geocoder
+
+geocoder = Geocoder()
+
+
+@pytest.mark.asyncio
+@patch("requests.get")
+async def test_get_geocoder_info_returns_right_location_when_found_by_geocoder(
+    mock_get,
+):
+    expected_get_geocoder_api_output = {
+        "features": [
+            {
+                "geometry": {
+                    "coordinates": [151.2164539, -33.8548157],
+                    "type": "Point",
+                },
+                "type": "Feature",
+                "properties": {
+                    "osm_id": 5750005,
+                    "osm_type": "R",
+                    "extent": [150.260825, -33.3641481, 151.343898, -34.1732416],
+                    "country": "Australia",
+                    "osm_key": "place",
+                    "countrycode": "AU",
+                    "osm_value": "city",
+                    "name": "Sydney",
+                    "state": "New South Wales",
+                    "type": "city",
+                },
+            },
+            {
+                "geometry": {"coordinates": [151.210047, -33.8679574], "type": "Point"},
+                "type": "Feature",
+                "properties": {
+                    "osm_id": 5729534,
+                    "osm_type": "R",
+                    "extent": [151.1970047, -33.8561096, 151.223011, -33.8797564],
+                    "country": "Australia",
+                    "osm_key": "place",
+                    "city": "Council of the City of Sydney",
+                    "countrycode": "AU",
+                    "osm_value": "suburb",
+                    "postcode": "2000",
+                    "name": "Sydney",
+                    "state": "New South Wales",
+                    "type": "district",
+                },
+            },
+        ]
+    }
+
+    # Generate expected output from both get requests
+    mock_get.return_value.json.return_value = expected_get_geocoder_api_output
+
+    expected_output = [
+        {
+            "bounding_box": expected_get_geocoder_api_output["features"][0][
+                "properties"
+            ]["extent"],
+            "name": expected_get_geocoder_api_output["features"][0]["properties"][
+                "name"
+            ],
+            "country": expected_get_geocoder_api_output["features"][0]["properties"][
+                "country"
+            ],
+            "coordinates": expected_get_geocoder_api_output["features"][0]["geometry"][
+                "coordinates"
+            ],
+        }
+    ]
+    response = geocoder.get_location_info("sydney")
+
+    assert mock_get.called
+    assert response == expected_output
+
+
+@pytest.mark.asyncio
+@patch("requests.get")
+async def test_get_location_info_returns_right_location_when_found_by_geocoder_and_geonames(
+    mock_get,
+):
+    expected_get_geocoder_api_output = {
+        "features": [
+            {
+                "geometry": {
+                    "coordinates": [151.2164539, -33.8548157],
+                    "type": "Point",
+                },
+                "type": "Feature",
+                "properties": {
+                    "osm_id": 5750005,
+                    "osm_type": "R",
+                    "extent": [150.260825, -33.3641481, 151.343898, -34.1732416],
+                    "country": "Australia",
+                    "osm_key": "place",
+                    "countrycode": "AU",
+                    "osm_value": "city",
+                    "name": "Sydney",
+                    "state": "New South Wales",
+                    "type": "city",
+                },
+            },
+            {
+                "geometry": {"coordinates": [151.210047, -33.8679574], "type": "Point"},
+                "type": "Feature",
+                "properties": {
+                    "osm_id": 5729534,
+                    "osm_type": "R",
+                    "extent": [151.1970047, -33.8561096, 151.223011, -33.8797564],
+                    "country": "Australia",
+                    "osm_key": "place",
+                    "city": "Council of the City of Sydney",
+                    "countrycode": "AU",
+                    "osm_value": "suburb",
+                    "postcode": "2000",
+                    "name": "Sydney",
+                    "state": "New South Wales",
+                    "type": "district",
+                },
+            },
+        ]
+    }
+    expected_get_geonames_api_output = [
+        {
+            "name": "Sydney",
+            "latitude": "-33.86778",
+            "longitude": "151.20844",
+            "country": "Australia",
+            "continent": "Oceania",
+        }
+    ]
+    # Generate expected output from both get requests
+    mock_get.return_value.json.return_value = "test"
+    mock_get.return_value.json.side_effect = [
+        expected_get_geocoder_api_output,
+        expected_get_geonames_api_output,
+    ]
+    expected_output = [
+        {
+            "bounding_box": expected_get_geocoder_api_output["features"][0][
+                "properties"
+            ]["extent"],
+            "name": expected_get_geocoder_api_output["features"][0]["properties"][
+                "name"
+            ],
+            "country": expected_get_geocoder_api_output["features"][0]["properties"][
+                "country"
+            ],
+            "coordinates": expected_get_geocoder_api_output["features"][0]["geometry"][
+                "coordinates"
+            ],
+        }
+    ]
+    response = geocoder.get_location_info("sydney")
+
+    assert mock_get.called
+    assert response == expected_output
+
+
+@pytest.mark.asyncio
+@patch("requests.get")
+async def test_get_location_info_returns_empty_list_when_location_found_by_geocoder_cant_be_validated_by_geonames(
+    mock_get,
+):
+    expected_get_geocoder_api_output_2 = {
+        "features": [
+            {
+                "geometry": {
+                    "coordinates": [103.54583559171158, 1.3152402],
+                    "type": "Point",
+                },
+                "type": "Feature",
+                "properties": {
+                    "osm_id": 412628254,
+                    "osm_type": "W",
+                    "extent": [103.5425018, 1.320748, 103.5483276, 1.3097538],
+                    "country": "Malaysia",
+                    "osm_key": "place",
+                    "countrycode": "MY",
+                    "osm_value": "island",
+                    "name": "Asia Petroleum Hub",
+                    "type": "locality",
+                },
+            }
+        ]
+    }
+    expected_get_geonames_api_output_2 = [{}]
+    # Generate expected output from both get requests
+    mock_get.return_value.json.side_effect = [
+        expected_get_geocoder_api_output_2,
+        expected_get_geonames_api_output_2,
+    ]
+    expected_output = []
+    response = geocoder.get_location_info("asia petroleum hub")
+    print(response)
+    assert mock_get.called
+    assert response == expected_output

--- a/tests/test_validate_location.py
+++ b/tests/test_validate_location.py
@@ -53,6 +53,25 @@ location_output_texas = {
 
 
 @patch("geocoder_module.geocoder.Geocoder.get_location_info")
+def test_location_is_returned_valid_if_there_is_only_one_in_article(
+    mock_get_location_info,
+):
+    locations = [
+        location_output_old_paris,
+    ]
+    # Generate expected output from nlp-api response and add it to mock
+
+    mock_get_location_info.return_value = [location_output_old_paris]
+
+    # Get response
+    response = geocoder.double_check_countries(locations)
+
+    expected_output = [location_output_old_paris]
+
+    assert response == expected_output
+
+
+@patch("geocoder_module.geocoder.Geocoder.get_location_info")
 def test_updated_location_is_returned_when_location_is_validated_with_others_in_article(
     mock_get_location_info,
 ):

--- a/tests/test_validate_location.py
+++ b/tests/test_validate_location.py
@@ -1,0 +1,179 @@
+from unittest.mock import Mock, patch
+import pytest
+
+from geocoder_module.geocoder import Geocoder
+
+geocoder = Geocoder()
+
+location_output_brussels = {
+    "name": "Brussels",
+    "bounding_box": [2.224122, 48.902156, 2.4697602, 48.8155755],
+    "country": "Belgium",
+    "coordinates": [2.3514616, 48.8566969],
+}
+
+location_output_belgium = {
+    "name": "Belgium",
+    "bounding_box": [-98.8131865, 29.7309623, -98.2230029, 29.1862572],
+    "country": "Belgium",
+    "coordinates": [-98.4951405, 29.4246002],
+}
+
+location_output_united_states = {
+    "name": "United States",
+    "bounding_box": [-98.8131865, 29.7309623, -98.2230029, 29.1862572],
+    "country": "United States",
+    "coordinates": [-98.4951405, 29.4246002],
+}
+
+location_output_old_paris = {
+    "name": "Paris",
+    "bounding_box": [2.224122, 48.902156, 2.4697602, 48.8155755],
+    "country": "France",
+    "coordinates": [2.3514616, 48.8566969],
+}
+location_output_new_paris = {
+    "name": "Paris",
+    "bounding_box": [-95.6279396, 33.7383866, -95.4354115, 33.6206345],
+    "country": "United States",
+    "coordinates": [-95.555513, 33.6617962],
+}
+location_output_san_antonio = {
+    "name": "San Antonio",
+    "bounding_box": [-98.8131865, 29.7309623, -98.2230029, 29.1862572],
+    "country": "United States",
+    "coordinates": [-98.4951405, 29.4246002],
+}
+location_output_texas = {
+    "name": "Texas",
+    "bounding_box": [-106.6458459, 36.5004529, -93.5078217, 25.83706],
+    "country": "United States",
+    "coordinates": [-99.5120986, 31.8160381],
+}
+
+
+@patch("geocoder_module.geocoder.Geocoder.get_location_info")
+def test_updated_location_is_returned_when_location_is_validated_with_others_in_article(
+    mock_get_location_info,
+):
+    locations = [
+        location_output_old_paris,
+        location_output_san_antonio,
+        location_output_texas,
+    ]
+    # Generate expected output from nlp-api response and add it to mock
+
+    mock_get_location_info.return_value = [location_output_new_paris]
+
+    # Get response
+    response = geocoder.double_check_countries(locations)
+
+    expected_output = [
+        location_output_new_paris,
+        location_output_san_antonio,
+        location_output_texas,
+    ]
+
+    assert response == expected_output
+
+
+def test_same_location_is_returned_when_location_is_same_than_others_in_article():
+
+    locations = [
+        location_output_san_antonio,
+        location_output_texas,
+    ]
+    # Generate expected output from nlp-api response and add it to mock
+
+    # Get response
+    response = geocoder.double_check_countries(locations)
+
+    expected_output = [
+        location_output_san_antonio,
+        location_output_texas,
+    ]
+
+    assert response == expected_output
+
+
+@patch("geocoder_module.geocoder.Geocoder.get_location_info")
+def test_updated_location_is_returned_when_location_is_same_than_others_in_article_and_only_1_reference_to_country(
+    mock_get_location_info,
+):
+
+    locations = [
+        location_output_united_states,
+        location_output_san_antonio,
+        location_output_texas,
+        location_output_old_paris,
+    ]
+    # Generate expected output from nlp-api response and add it to mock
+    mock_get_location_info.return_value = [location_output_new_paris]
+    # Get response
+    response = geocoder.double_check_countries(locations)
+
+    expected_output = [
+        location_output_united_states,
+        location_output_san_antonio,
+        location_output_texas,
+        location_output_new_paris,
+    ]
+
+    assert response == expected_output
+
+
+@patch("geocoder_module.geocoder.Geocoder.get_location_info")
+def test_discarded_location_when_location_is_not_in_countries_locations(
+    mock_get_location_info,
+):
+    locations = [
+        location_output_united_states,
+        location_output_belgium,
+        location_output_san_antonio,
+        location_output_texas,
+        location_output_old_paris,
+    ]
+    # Generate expected output from nlp-api response and add it to mock
+    mock_get_location_info.return_value = [location_output_old_paris]
+    # Get response
+    response = geocoder.double_check_countries(locations)
+
+    expected_output = [
+        location_output_united_states,
+        location_output_belgium,
+        location_output_san_antonio,
+        location_output_texas,
+        {},
+    ]
+
+    assert response == expected_output
+
+
+@patch("geocoder_module.geocoder.Geocoder.get_location_info")
+def test_retain_all_locations_in_country_when_location_is_in_countries_location(
+    mock_get_location_info,
+):
+
+    locations = [
+        location_output_united_states,
+        location_output_belgium,
+        location_output_san_antonio,
+        location_output_texas,
+        location_output_old_paris,
+        location_output_brussels,
+    ]
+    # Generate expected output from nlp-api response and add it to mock
+    mock_get_location_info.return_value = [location_output_old_paris]
+    # Get response
+    response = geocoder.double_check_countries(locations)
+
+    expected_output = [
+        location_output_united_states,
+        location_output_belgium,
+        location_output_san_antonio,
+        location_output_texas,
+        {},
+        location_output_brussels,
+    ]
+
+    assert response == expected_output


### PR DESCRIPTION
# Why
Currently a lot of the location we retrieve from the geocoder service are wrong. Therefore we needed a validation step that compared and ensured that a location can be found in at least 2 location services.

# What
- Integration of geonames service into geocoder module and additional validation steps
- New unit tests
- Updated docs