### PR TITLE
Fixes IndexError bug in get_location_info function

### DIFF
--- a/geocoder_module/geocoder.py
+++ b/geocoder_module/geocoder.py
@@ -263,6 +263,9 @@ class Geocoder:
                         validated_results.append(geocode_hit)
                 else:
                     continue
+        logging.warning(f"Location validation failed for {location}")
+        if validated_results == []:
+            validated_results = [{}]
         return validated_results
 
     def get_country_neighbors(self, country: str) -> List[str]:
@@ -362,7 +365,14 @@ class Geocoder:
                                number of countries to check as a reference
         :param ner_location_tags:  list of ner tags associated to locations to be filtered to countries
         """
+        # Initialise mappings and only countries dictionaries
+        mapping_countries = {}
+        only_countries = {}
+        countries = []
         ner_countries, ner_local = self.filter_ner_countries(ner_tags)
+        ner_countries_count = []
+
+        # Extract uk nations
         ner_uk_nations = [
             tag["name"]
             for tag in ner_local
@@ -370,22 +380,16 @@ class Geocoder:
             in ["england", "wales", "northern ireland", "scotland"]
         ]
         # Normalise country name
-        ner_countries = [
-            self.get_location_info(
-                tag["name"], country=tag["name"], best_matching=True
-            )[0]
-            for tag in ner_countries
-        ]
-        # Create ner countries list
-        ner_countries_count = []
-        for ner_country in ner_countries:
-            ner_countries_count.append(ner_country["country"])
-
-        # Initialise mappings and only countries dictionaries
-        mapping_countries = {}
-        only_countries = {}
-
-        countries = []
+        if ner_countries != []:
+            ner_countries = [
+                self.get_location_info(
+                    tag["name"], country=tag["name"], best_matching=True
+                )[0]
+                for tag in ner_countries
+            ]
+            # Create ner countries list
+            for ner_country in ner_countries:
+                ner_countries_count.append(ner_country["country"])
 
         # create a default mapping and extract all the countries
         for location in locations:

--- a/geocoder_module/geocoder.py
+++ b/geocoder_module/geocoder.py
@@ -263,9 +263,10 @@ class Geocoder:
                         validated_results.append(geocode_hit)
                 else:
                     continue
-        logging.warning(f"Location validation failed for {location}")
         if validated_results == []:
             validated_results = [{}]
+            logging.warning(f"Location validation failed for {location}")
+
         return validated_results
 
     def get_country_neighbors(self, country: str) -> List[str]:
@@ -334,7 +335,7 @@ class Geocoder:
                 name, country=new_country, best_matching=True
             )
             # check if the reference country can be used for this location
-            if new_location != []:
+            if new_location != [{}]:
                 mapping_countries[name] = new_location[0]["country"]
 
         return mapping_countries
@@ -389,7 +390,8 @@ class Geocoder:
             ]
             # Create ner countries list
             for ner_country in ner_countries:
-                ner_countries_count.append(ner_country["country"])
+                if ner_country:
+                    ner_countries_count.append(ner_country["country"])
 
         # create a default mapping and extract all the countries
         for location in locations:

--- a/tests/test_get_location.py
+++ b/tests/test_get_location.py
@@ -198,7 +198,7 @@ def test_get_location_info_returns_empty_list_when_location_found_by_geocoder_ca
         expected_get_geocoder_api_output_2,
         expected_get_geonames_api_output_2,
     ]
-    expected_output = []
+    expected_output = [{}]
     response = geocoder.get_location_info("asia petroleum hub")
     print(response)
     assert mock_get.called


### PR DESCRIPTION
## Why?

There was an IndexError in the get_location_info function output that was caused by returning empty lists if the validation failed. This PR addressed that issue.

## What?
- Refactors empty vars definition on double_check_country and adds a empty list check before computing ner_countries
- Adds check before get_location_info return that ensures no empty list is returned