### PR TITLE
feat(AS-1749): Implements acronym dictionary

### DIFF
--- a/geocoder_module/countries_acronyms.json
+++ b/geocoder_module/countries_acronyms.json
@@ -1,0 +1,733 @@
+{
+    "united arab emirates": [
+        "oaeh",
+        "uae",
+        "\u043e\u0430\u044d",
+        "\u963f\u8054\u914b"
+    ],
+    "united kingdom": [
+        "uk",
+        "u.k.",
+        "u.k",
+        "gb",
+        "g.b.",
+        "g.b"
+    ],
+    "antigua and barbuda": [],
+    "anguilla": [
+        "axa",
+        "\u30a2\u30f3\u30ae\u30e9",
+        "\u5b89\u572d\u62c9",
+        "\uc575\uadc8\ub77c"
+    ],
+    "armenia": [],
+    "netherlands antilles": [],
+    "antarctica": [
+        "\u5357\u6781\u6d32",
+        "\u5357\u6975",
+        "\u5357\u6975\u6d32"
+    ],
+    "argentina": [],
+    "american samoa": [],
+    "aruba": [
+        "\u0d05\u0d31\u0d41\u0d2c",
+        "\u0d05\u0d31\u0d42\u0d2c",
+        "\u0d85\u0dbb\u0db6\u0dcf",
+        "\u12a0\u1229\u1263",
+        "\u12a3\u1229\u1263",
+        "\u30a2\u30eb\u30d0",
+        "\u30a2\u30eb\u30d0\u5cf6",
+        "\u963f\u9b6f\u5df4",
+        "\u963f\u9c81\u5df4",
+        "\uc544\ub8e8\ubc14"
+    ],
+    "aland islands": [],
+    "bosnia and herzegovina": [
+        "\u6ce2\u65af\u5c3c\u4e9e",
+        "\u6ce2\u9ed1",
+        "\ubcf4\uc2a4\ub2c8\uc544"
+    ],
+    "barbados": [],
+    "bangladesh": [
+        "\u5b5f\u52a0\u62c9",
+        "\u5b5f\u52a0\u62c9\u56fd",
+        "\u5b5f\u52a0\u62c9\u570b"
+    ],
+    "burkina faso": [],
+    "bahrain": [
+        "awal",
+        "aw\u0101l"
+    ],
+    "benin": [],
+    "saint barthelemy": [
+        "sbh",
+        "\u8056\u5df4\u745f\u7c73"
+    ],
+    "bermuda": [
+        "bda",
+        "\u1264\u122d\u1219\u12f3",
+        "\u767e\u6155\u5927",
+        "\u767e\u6155\u9054",
+        "\ubc84\ubba4\ub2e4"
+    ],
+    "bouvet island": [
+        "buve",
+        "\u10d1\u10e3\u10d5\u10d4",
+        "\u30d6\u30fc\u30d9\u5cf6",
+        "\u5e03\u5a01\u5cf6",
+        "\u5e03\u7ef4\u5c9b",
+        "\u5e03\u7ef4\u7279\u5c9b",
+        "\u5e03\u97e6\u5c9b",
+        "\ubd80\ubca0 \uc12c",
+        "\ubd80\ubca0\uc12c"
+    ],
+    "belize": [
+        "blyz",
+        "\u05d1\u05dc\u05d9\u05d6",
+        "\u0628\u0644\u064a\u0632",
+        "\u0628\u0644\u06cc\u0632",
+        "\u0ec0\u0e9a\u0ea5\u0e8a",
+        "\u0f56\u0f0b\u0f63\u0f5b",
+        "\u1260\u120a\u12dd",
+        "\u1264\u120a\u12d8",
+        "\u1264\u120a\u12dd",
+        "\u1794\u17c1\u179b",
+        "\u1794\u17c1\u179b\u17b8",
+        "\u30d9\u30ea\u30fc\u30ba",
+        "\u4f2f\u5229\u5179",
+        "\u4f2f\u5229\u8332",
+        "\u8c9d\u91cc\u65af",
+        "\ubca8\ub9ac\uc988"
+    ],
+    "canada": [
+        "knda",
+        "qndh",
+        "\u05e7\u05e0\u05d3\u05d4",
+        "\u0643\u0646\u062f\u0627",
+        "\u0b95\u0ba9\u0b9f\u0bbe",
+        "\u0d15\u0d3e\u0d28\u0d21",
+        "\u12ab\u1293\u12f3",
+        "\u30ab\u30ca\u30c0",
+        "\u52a0\u62ff\u5927",
+        "\uce90\ub098\ub2e4"
+    ],
+    "cocos islands": [
+        "cck",
+        "\u79d1\u79d1\u65af"
+    ],
+    "democratic republic of the congo": [
+        "rdc",
+        "zair",
+        "zyyr",
+        "\u0437\u0430\u0438\u0440",
+        "\u0632\u0626\u06cc\u0631",
+        "\u12ae\u1295\u130e",
+        "\u30b6\u30a4\u30fc\u30eb",
+        "\u624e\u4f0a\u5c14"
+    ],
+    "central african republic": [
+        "\u4e2d\u975e"
+    ],
+    "republic of the congo": [
+        "\u30b3\u30f3\u30b4",
+        "\u521a\u679c",
+        "\ucf69\uace0"
+    ],
+    "switzerland": [
+        "ch",
+        "suis",
+        "swys",
+        "\u0633\u0648\u06cc\u0633",
+        "\u179f\u179c\u179f",
+        "\u30b9\u30a4\u30b9",
+        "\u745e\u58eb",
+        "\uc2a4\uc704\uc2a4"
+    ],
+    "cook islands": [],
+    "colombia": [],
+    "serbia and montenegro": [
+        "cs",
+        "scg"
+    ],
+    "cuba": [
+        "cuba"
+    ],
+    "christmas island": [
+        "xch"
+    ],
+    "cyprus": [],
+    "czechia": [
+        "cz",
+        "ceki",
+        "ceko",
+        "c\u00e9ko",
+        "chek",
+        "chk",
+        "\u00e7eki",
+        "\u0447\u0435\u0445",
+        "\u0447\u0435\u0445\u0438",
+        "\u062a\u0634\u064a\u0643",
+        "\u0686\u06a9",
+        "\u0686\u06a9\u06cc\u0627",
+        "\u072c\u072b\u071d\u071f",
+        "\u0e40\u0e0a\u0e47\u0e01",
+        "\u127c\u127a\u12eb",
+        "\u1786\u17c2\u1780",
+        "\u30c1\u30a7\u30b3",
+        "\u6377\u514b",
+        "\uccb4\ucf54"
+    ],
+    "djibouti": [
+        "jib",
+        "\u30b8\u30d6\u30c1\u5e02",
+        "\u5409\u5e03\u5730\u5e02",
+        "\u5409\u5e03\u63d0\u57ce",
+        "\uc9c0\ubd80\ud2f0"
+    ],
+    "dominica": [],
+    "dominican republic": [
+        "\u591a\u660e\u5c3c\u52a0",
+        "\u591a\u7c73\u5c3c\u52a0"
+    ],
+    "western sahara": [
+        "eh",
+        "rasd",
+        "\u897f\u30b5\u30cf\u30e9",
+        "\u897f\u6492\u54c8\u62c9",
+        "\uc11c\uc0ac\ud558\ub77c"
+    ],
+    "falkland islands": [],
+    "faroe islands": [
+        "\u6cd5\u7f57\u7fa4\u5c9b",
+        "\u6cd5\u7f85\u7fa4\u5cf6",
+        "\ud398\ub85c\uc81c\ub3c4"
+    ],
+    "france": [],
+    "grenada": [],
+    "georgia": [
+        "\u0433\u04af\u0440\u0436",
+        "\u0e88\u0ec0\u0e88\u0e8d",
+        "\u0f47\u0f62\u0f0b\u0f47",
+        "\u1306\u122d\u1302\u12eb",
+        "\u30b0\u30eb\u30b8\u30a2",
+        "\u55ac\u6cbb\u4e9e",
+        "\u683c\u9b6f\u5409\u4e9e",
+        "\u683c\u9c81\u5409\u4e9a",
+        "\uadf8\ub8e8\uc9c0\uc544",
+        "\uadf8\ub8e8\uc9c0\uc57c",
+        "\uc870\uc9c0\uc544"
+    ],
+    "guernsey": [
+        "gci",
+        "\u6839\u897f\u5c9b",
+        "\uac74\uc9c0 \uc12c"
+    ],
+    "gibraltar": [
+        "\u76f4\u5e03\u7f57\u9640",
+        "\u76f4\u5e03\u7f85\u9640",
+        "\uc9c0\ube0c\ub864\ud130"
+    ],
+    "greenland": [
+        "\u683c\u9675\u5170",
+        "\u683c\u9675\u862d",
+        "\uadf8\ub9b0\ub780\ub4dc",
+        "\uadf8\ub9b0\ub79c\ub4dc"
+    ],
+    "gambia": [
+        "\u130b\u121d\u1262\u12eb",
+        "\u17a0\u1782\u1794",
+        "\u30ac\u30f3\u30d3\u30a2",
+        "\u5188\u6bd4\u4e9a",
+        "\u7518\u6bd4\u4e9e",
+        "\uac10\ube44\uc544"
+    ],
+    "guadeloupe": [],
+    "south georgia and the south sandwich islands": [],
+    "guam": [
+        "gum",
+        "guam",
+        "gu\u00e2m",
+        "gvam",
+        "gwam",
+        "quam",
+        "guam",
+        "gvam",
+        "gwam",
+        "kwm",
+        "\u0433\u0443\u0430\u043c",
+        "\u05d2\u05d5\u05d0\u05dd",
+        "\u063a\u0648\u0627\u0645",
+        "\u06abwam",
+        "\u06ab\u0648\u0627\u0645",
+        "\u06af\u0648\u0627\u0645",
+        "\u0917\u0941\u0906\u092e",
+        "\u0a17\u0a41\u0a06\u0a2e",
+        "\u0d9c\u0dc0\u0dcf\u0db8",
+        "\u0e01\u0e27\u0e21",
+        "\u0e81\u0ea7\u0eb2\u0ea1",
+        "\u1309\u12cb\u121d",
+        "\u17a0\u1782\u17b6",
+        "\u30b0\u30a2\u30e0",
+        "\u5173\u5c9b",
+        "\u95dc\u5cf6",
+        "\uad0c"
+    ],
+    "hong kong": [
+        "hkg",
+        "\u0939\u0919\u0915\u0919",
+        "\u09b9\u0982\u0995\u0982",
+        "\u0b39\u0b02\u0b15\u0b02",
+        "\u17a0\u1784\u1780\u1784",
+        "\u9999\u6e2f",
+        "\ud64d\ucf69"
+    ],
+    "hungary": [
+        "hu",
+        "mgr",
+        "mjr",
+        "\u046b\u0433\u0440\u0438",
+        "\u0645\u062c\u0631",
+        "\u0721\u0713\u072a",
+        "\u1200\u1295\u130b\u122a",
+        "\uab82\uab92\uab76\uab85",
+        "\u17a0\u1784\u1782\u179a",
+        "\u5308\u7259\u5229",
+        "\ud5dd\uac00\ub9ac"
+    ],
+    "ireland": [
+        "eire",
+        "ie",
+        "iiri",
+        "ire",
+        "\u00e9ire",
+        "\u611b\u723e\u862d",
+        "\u7231\u5c14\u5170",
+        "\uc544\uc77c\ub79c\ub4dc"
+    ],
+    "isle of man": [
+        "iom",
+        "man",
+        "mann",
+        "men",
+        "moen",
+        "m\u00f6n",
+        "\u043c\u0435\u043d",
+        "\u30de\u30f3\u5cf6",
+        "\u66fc\u5c9b",
+        "\u66fc\u5cf6",
+        "\u9a6c\u6069\u5c9b",
+        "\ub9e8 \uc12c",
+        "\ub9e8\uc12c"
+    ],
+    "british indian ocean territory": [],
+    "iran": [
+        "iran",
+        "\u012br\u0101n"
+    ],
+    "jersey": [
+        "jer",
+        "\u6fa4\u897f\u5cf6",
+        "\uc800\uc9c0 \uc12c"
+    ],
+    "jamaica": [],
+    "japan": [
+        "hapo",
+        "hap\u00f5",
+        "japo",
+        "japu",
+        "jap\u00f3",
+        "zap\u0254",
+        "jpan",
+        "ypn",
+        "\u044f\u043f\u043e\u043d",
+        "\u05d9\u05e4\u05df",
+        "\u062c\u067e\u0627\u0646",
+        "\u0698\u0627\u067e\u0646",
+        "\u071d\u0726\u0722",
+        "\u091c\u092a\u093e\u0928",
+        "\u0a1c\u0a2a\u0a3e\u0a28",
+        "\u0e8d\u0e9b\u0e99",
+        "\u0f47\u0f0b\u0f54\u0f53",
+        "\u1303\u1353\u1295",
+        "\uabb3\uabb9\uab92\uab9f",
+        "\u14c3\u1449\u140a\u14d0",
+        "\u1787\u1794\u1793",
+        "\u1a0d\u1a1b\u1a04",
+        "\u65e5\u672c",
+        "\ua3dd\ua02a",
+        "\uc77c\ubcf8"
+    ],
+    "kyrgyzstan": [],
+    "cayman islands": [],
+    "kazakhstan": [],
+    "lebanon": [
+        "liba",
+        "lib\u00e1",
+        "lbnn",
+        "\u0720\u0712\u0722\u0722",
+        "\u120a\u1263\u1296\u1235",
+        "\u179b\u1794\u1784",
+        "\u30ec\u30d0\u30ce\u30f3",
+        "\u9ece\u5df4\u5ae9",
+        "\ub808\ubc14\ub17c"
+    ],
+    "saint lucia": [
+        "\u5723\u5362\u897f\u4e9a",
+        "\u8056\u9732\u897f\u4e9e"
+    ],
+    "sri lanka": [],
+    "luxembourg": [
+        "lux",
+        "\u76e7\u68ee\u5821\u57ce",
+        "\u76e7\u68ee\u5821\u5e02"
+    ],
+    "libya": [
+        "libi",
+        "lib\u00ed",
+        "livi",
+        "lbya",
+        "lwb",
+        "lyby",
+        "\u043b\u0438\u0432\u0438",
+        "\u05dc\u05d5\u05d1",
+        "\u0644\u0628\u064a\u0627",
+        "\u0644\u06cc\u0628\u06cc",
+        "\u0720\u0718\u0712\u0710",
+        "\u0ea5\u0ec0\u0e9a\u0e8d",
+        "\u120a\u1262\u12eb",
+        "\u179b\u1794",
+        "\u30ea\u30d3\u30a2",
+        "\u5229\u6bd4\u4e9a",
+        "\u5229\u6bd4\u4e9e",
+        "\ub9ac\ube44\uc544"
+    ],
+    "monaco": [
+        "mcm",
+        "\ubaa8\ub098\ucf54"
+    ],
+    "montenegro": [
+        "me",
+        "\u9ed1\u5c71"
+    ],
+    "saint martin": [
+        "sfg",
+        "\u5723\u9a6c\u4e01\u5c9b"
+    ],
+    "madagascar": [],
+    "marshall islands": [],
+    "north macedonia": [
+        "arym",
+        "mk",
+        "\u5317\u99ac\u5176\u9813",
+        "\u5317\u9a6c\u5176\u987f"
+    ],
+    "mongolia": [
+        "mool",
+        "\u043c\u043e\u043e\u043b",
+        "\u30e2\u30f3\u30b4\u30eb",
+        "\u8499\u53e4",
+        "\u8499\u53e4\u56fd",
+        "\u8499\u53e4\u570b",
+        "\ubabd\uace8"
+    ],
+    "northern mariana islands": [],
+    "martinique": [],
+    "montserrat": [],
+    "malta": [
+        "malt",
+        "mlth",
+        "\u05de\u05dc\u05d8\u05d4",
+        "\u0645\u0627\u0644\u062a",
+        "\u30de\u30eb\u30bf\u5cf6",
+        "\u99ac\u8033\u4ed6\u5cf6",
+        "\ubab0\ud0c0 \uc12c"
+    ],
+    "mauritius": [],
+    "malawi": [],
+    "mexico": [],
+    "malaysia": [
+        "\u121b\u120c\u12e2\u12eb",
+        "\u99ac\u4f86\u897f\u4e9e",
+        "\u9a6c\u6765\u897f\u4e9a"
+    ],
+    "mozambique": [],
+    "new caledonia": [],
+    "norfolk island": [
+        "nlk",
+        "\u8bfa\u798f\u514b\u5c9b",
+        "\ub178\ud37d \uc12c"
+    ],
+    "nepal": [],
+    "nauru": [
+        "naru",
+        "n\u00e1r\u00fa",
+        "naru",
+        "nwrw",
+        "\u0646\u0624\u0631\u0648",
+        "\u0646\u0648\u0631\u0648",
+        "\u0928\u094c\u0930\u0941",
+        "\u0928\u094c\u0930\u0942",
+        "\u0aa8\u0acc\u0ab0\u0ac1",
+        "\u0ba8\u0bcc\u0bb0\u0bc1",
+        "\u0c28\u0c4c\u0c30\u0c41",
+        "\u0ca8\u0ccc\u0cb0\u0cc1",
+        "\u0d28\u0d57\u0d31\u0d41",
+        "\u0d28\u0d57\u0d31\u0d42",
+        "\u0e99\u0eb2\u0ead\u0ea3",
+        "\u1293\u12a1\u1229",
+        "\u1293\u12cd\u1229",
+        "\u178e\u179a",
+        "\u178e\u17bc\u179a\u17bc",
+        "\u30ca\u30a6\u30eb",
+        "\u7459\u9b6f",
+        "\u7459\u9c81",
+        "\u8afe\u9b6f",
+        "\ub098\uc6b0\ub8e8"
+    ],
+    "niue": [
+        "iue",
+        "nija",
+        "nioe",
+        "nio\u00e9",
+        "niue",
+        "niui",
+        "niuo",
+        "niu\u00e8",
+        "niu\u00e9",
+        "niu\u0113",
+        "niw",
+        "niwe",
+        "niyu",
+        "ni\u00fbe",
+        "nju",
+        "nyue",
+        "nyu\u00e9",
+        "ni'u",
+        "niue",
+        "niyu",
+        "nu'u",
+        "nwwy",
+        "nyw",
+        "nyww",
+        "nywy",
+        "nyyw",
+        "\u043d\u0438\u0443\u0435",
+        "\u043d\u0438\u0443\u044d",
+        "\u043d\u0456\u0443\u0435",
+        "\u043d\u0456\u0443\u044d",
+        "\u043d\u0456\u044f",
+        "\u05e0\u05d9\u05d0\u05d5",
+        "\u0646\u0648\u0648\u064a",
+        "\u0646\u064a\u0648\u064a",
+        "\u0646\u06cc\u0626\u0648",
+        "\u0646\u06cc\u0648\u0648",
+        "\u0646\u06cc\u0648\u0657",
+        "\u0782\u07a9\u0787\u07aa",
+        "\u0928\u0940\u092f\u0942",
+        "\u09a8\u09bf\u0989",
+        "\u09a8\u09c1\u0989",
+        "\u0a28\u0a3f\u0a0a\u0a0f",
+        "\u0a28\u0a3f\u0a2f\u0a42",
+        "\u0aa8\u0ac0\u0aaf\u0ac1",
+        "\u0b28\u0b3f\u0b09",
+        "\u0ba8\u0bbf\u0baf\u0bc2",
+        "\u0c28\u0c3f\u0c2f\u0c42",
+        "\u0ca8\u0cbf\u0caf\u0cc1",
+        "\u0db1\u0dd2\u0dba\u0dd6",
+        "\u0e99\u0ead\u0ec0\u0ead",
+        "\u10dc\u10d8\u10e3\u10d4",
+        "\u1292\u12a1\u12ed",
+        "\u178e\u17c0",
+        "\u30cb\u30a6\u30a8",
+        "\u30cb\u30a6\u30a8\u5cf6",
+        "\u7d10\u57c3",
+        "\u7d10\u57c3\u5cf6",
+        "\u7ebd\u57c3",
+        "\ub2c8\uc6b0\uc5d0"
+    ],
+    "new zealand": [
+        "\u65b0\u897f\u5170",
+        "\u7d10\u897f\u862d",
+        "\ub274\uc9c8\ub79c\ub4dc"
+    ],
+    "panama": [
+        "pty",
+        "\u5df4\u62ff\u99ac\u57ce"
+    ],
+    "french polynesia": [],
+    "philippines": [],
+    "pakistan": [],
+    "saint pierre and miquelon": [],
+    "puerto rico": [
+        "\u6ce2\u591a\u9ece\u5404"
+    ],
+    "portugal": [],
+    "qatar": [],
+    "reunion": [],
+    "romania": [
+        "ro",
+        "\u122e\u121b\u1295\u12eb",
+        "\u122e\u121c\u1292\u12eb",
+        "\uab86\uab89\uab92\uabbf",
+        "\u179a\u1798\u17b6\u1793",
+        "\u7f57\u9a6c\u5c3c\u4e9a",
+        "\u7f85\u99ac\u5c3c\u4e9e",
+        "\ub8e8\ub9c8\ub2c8\uc544"
+    ],
+    "serbia": [
+        "rs",
+        "sebi",
+        "s\u00e8bi",
+        "\u1230\u122d\u1262\u12eb",
+        "\u1230\u122d\u1265\u12eb",
+        "\uaba2\uab98\uabbf",
+        "\u179f\u17c2\u1794",
+        "\u30bb\u30eb\u30d3\u30a2",
+        "\u585e\u5c14\u7ef4\u4e9a",
+        "\u585e\u723e\u7dad\u4e9e",
+        "\uc138\ub974\ube44\uc544"
+    ],
+    "solomon islands": [
+        "\uc194\ub85c\ubaac"
+    ],
+    "seychelles": [],
+    "singapore": [
+        "sin",
+        "\u65b0\u52a0\u5761",
+        "\u661f\u67b6\u5761",
+        "\uc2f1\uac00\ud3ec\ub974",
+        "\uc2f1\uac00\ud3f4"
+    ],
+    "saint helena": [
+        "hle"
+    ],
+    "svalbard and jan mayen": [
+        "\uc2a4\ubc1c\ubc14\ub974"
+    ],
+    "san marino": [
+        "sai",
+        "\u8056\u99ac\u529b\u8afe",
+        "\uc0b0\ub9c8\ub9ac\ub178"
+    ],
+    "somalia": [
+        "\u1231\u121b\u120c",
+        "\u1236\u121b\u120a\u12eb",
+        "\u30bd\u30de\u30ea\u30a2",
+        "\u7d22\u99ac\u5229\u4e9e",
+        "\u7d22\u99ac\u91cc",
+        "\u7d22\u9a6c\u91cc",
+        "\uc18c\ub9d0\ub9ac\uc544"
+    ],
+    "south sudan": [
+        "\u5357\u82cf\u4e39",
+        "\u5357\u8607\u4e39",
+        "\ub0a8\uc218\ub2e8"
+    ],
+    "sao tome and principe": [],
+    "el salvador": [],
+    "sint maarten": [
+        "sxm",
+        "\u5723\u9a6c\u4e01\u5c9b"
+    ],
+    "eswatini": [
+        "\u53f2\u74e6\u6fdf\u862d",
+        "\u65af\u5a01\u58eb\u5170"
+    ],
+    "turks and caicos islands": [],
+    "tokelau": [],
+    "turkmenistan": [],
+    "tuvalu": [
+        "\u0e95\u0ea7\u0eb2\u0ea5",
+        "\u1271\u126b\u1209",
+        "\u1791\u179c\u17b6\u179b",
+        "\u30c4\u30d0\u30eb",
+        "\u5410\u74e6\u9b6f",
+        "\u56fe\u74e6\u5362",
+        "\u5716\u74e6\u76e7",
+        "\ud22c\ubc1c\ub8e8"
+    ],
+    "taiwan": [
+        "\u53f0\u7063"
+    ],
+    "ukraine": [
+        "\u12e9\u12ad\u122c\u1295",
+        "\u4e4c\u514b\u5170",
+        "\u70cf\u514b\u862d"
+    ],
+    "united states minor outlying islands": [],
+    "united states": [
+        "a.s",
+        "abd",
+        "abs",
+        "ab\u015f",
+        "acsh",
+        "aish",
+        "aksh",
+        "anu",
+        "aqsh",
+        "as",
+        "dya",
+        "eua",
+        "im",
+        "ipa",
+        "jav",
+        "sa",
+        "sad",
+        "sam",
+        "shba",
+        "ssha",
+        "su",
+        "sua",
+        "us",
+        "u.s",
+        "u.s.",
+        "uda",
+        "usa",
+        "vs",
+        "vsa",
+        "zda",
+        "ps",
+        "\u03b7\u03c0\u03b1",
+        "\u0430\u0438\u0448",
+        "\u0430\u043a\u0448",
+        "\u0430\u043d\u0443",
+        "\u0430\u0446\u0448",
+        "\u0430\u049b\u0448",
+        "\u0438\u043c",
+        "\u0441\u0430\u0434",
+        "\u0441\u0430\u0449",
+        "\u0441\u0448\u0430",
+        "\u05e4\u05bf\u05e9",
+        "\u0d91.\u0da2",
+        "\u10d0\u10e8\u10e8",
+        "\u12e9 \u12a4\u1235",
+        "\u12e9\u12a4\u1235",
+        "\u30a2\u30e1\u30ea\u30ab",
+        "\u7f8e\u56fd",
+        "\u7f8e\u570b",
+        "\ua0b0\ua1e9",
+        "\ubbf8\uad6d"
+    ],
+    "uruguay": [],
+    "uzbekistan": [],
+    "saint vincent and the grenadines": [],
+    "british virgin islands": [
+        "bvi"
+    ],
+    "kosovo": [],
+    "mayotte": [
+        "mywt",
+        "\u05de\u05d9\u05d5\u05d8",
+        "\u0db8\u0dba\u0ddc\u0da7",
+        "\u0f58\u0f0b\u0f61\u0f4a",
+        "\u121c\u12ed\u12a6\u1274",
+        "\u1798\u17b6\u1799\u178f",
+        "\u30de\u30e8\u30c3\u30c8",
+        "\u99ac\u7d04\u7279\u5cf6",
+        "\u9a6c\u7ea6\u7279",
+        "\ub9c8\uc694\ud2b8",
+        "\ub9c8\uc694\ud2f0"
+    ],
+    "south africa": [],
+    "zimbabwe": []
+}

--- a/geocoder_module/countries_acronyms.json
+++ b/geocoder_module/countries_acronyms.json
@@ -1,10 +1,1332 @@
 {
+    "afghanistan": [
+        "afgh",
+        "af"
+    ],
+    "aland islands": [
+        "ax"
+    ],
+    "albania": [
+        "alb",
+        "al"
+    ],
+    "algeria": [
+        "algr",
+        "dz"
+    ],
+    "american samoa": [
+        "as"
+    ],
+    "andorra": [
+        "ando",
+        "ad"
+    ],
+    "angola": [
+        "ao"
+    ],
+    "anguilla": [
+        "axa",
+        "angu",
+        "ai",
+        "アンギラ",
+        "安圭拉",
+        "앵귈라"
+    ],
+    "antarctica": [
+        "aq",
+        "南极洲",
+        "南極",
+        "南極洲"
+    ],
+    "antigua and barbuda": [
+        "anti",
+        "ag"
+    ],
+    "argentina": [
+        "arg",
+        "ar"
+    ],
+    "armenia": [
+        "arm",
+        "am"
+    ],
+    "aruba": [
+        "aw",
+        "arb",
+        "അറുബ",
+        "അറൂബ",
+        "අරබා",
+        "አሩባ",
+        "ኣሩባ",
+        "アルバ",
+        "アルバ島",
+        "阿魯巴",
+        "阿鲁巴",
+        "아루바"
+    ],
+    "australia": [
+        "astl",
+        "au"
+    ],
+    "austria": [
+        "aust",
+        "at"
+    ],
+    "azerbaijan": [
+        "azr",
+        "az"
+    ],
+    "bahamas": [
+        "bama",
+        "bs"
+    ],
+    "bahrain": [
+        "bh",
+        "bahr",
+        "awal",
+        "awāl"
+    ],
+    "bangladesh": [
+        "bd",
+        "bang",
+        "孟加拉",
+        "孟加拉国",
+        "孟加拉國"
+    ],
+    "barbados": [
+        "brdo",
+        "bb"
+    ],
+    "belarus": [
+        "bys",
+        "by"
+    ],
+    "belgium": [
+        "belg",
+        "be"
+    ],
+    "belize": [
+        "bz",
+        "blz",
+        "blyz",
+        "בליז",
+        "بليز",
+        "بلیز",
+        "ເບລຊ",
+        "བ་ལཛ",
+        "በሊዝ",
+        "ቤሊዘ",
+        "ቤሊዝ",
+        "បេល",
+        "បេលី",
+        "ベリーズ",
+        "伯利兹",
+        "伯利茲",
+        "貝里斯",
+        "벨리즈"
+    ],
+    "benin": [
+        "benn",
+        "bj"
+    ],
+    "bermuda": [
+        "bm",
+        "berm",
+        "bda",
+        "ቤርሙዳ",
+        "百慕大",
+        "百慕達",
+        "버뮤다"
+    ],
+    "bhutan": [
+        "bhu",
+        "bt"
+    ],
+    "bolivia": [
+        "bol",
+        "bo"
+    ],
+    "bosnia and herzegovina": [
+        "bq",
+        "bih",
+        "波斯尼亞",
+        "波黑",
+        "보스니아"
+    ],
+    "botswana": [
+        "bot",
+        "bw"
+    ],
+    "bouvet island": [
+        "bv",
+        "buve",
+        "ბუვე",
+        "ブーベ島",
+        "布威島",
+        "布维岛",
+        "布维特岛",
+        "布韦岛",
+        "부베 섬",
+        "부베섬"
+    ],
+    "brazil": [
+        "brzl",
+        "br"
+    ],
+    "british indian ocean territory": [],
+    "british virgin islands": [
+        "vg",
+        "bvi",
+        "brvi"
+    ],
+    "brunei": [
+        "brni",
+        "bn"
+    ],
+    "bulgaria": [
+        "bulg",
+        "bg"
+    ],
+    "burkina faso": [
+        "burk",
+        "bf"
+    ],
+    "burma": [
+        "burm"
+    ],
+    "burundi": [
+        "brnd",
+        "bi"
+    ],
+    "cambodia": [
+        "cbda",
+        "kh"
+    ],
+    "cameroon": [
+        "cmrn",
+        "cm"
+    ],
+    "canada": [
+        "ca",
+        "can",
+        "knda",
+        "qndh",
+        "קנדה",
+        "كندا",
+        "கனடா",
+        "കാനഡ",
+        "ካናዳ",
+        "カナダ",
+        "加拿大",
+        "캐나다"
+    ],
+    "cape verde": [
+        "cavi",
+        "cv"
+    ],
+    "cayman islands": [
+        "cayi",
+        "ky"
+    ],
+    "central african republic": [
+        "cf",
+        "cafr",
+        "中非"
+    ],
+    "chad": [
+        "chad",
+        "td"
+    ],
+    "chile": [
+        "chil",
+        "cl"
+    ],
+    "china": [
+        "chin",
+        "cn"
+    ],
+    "christmas island": [
+        "cx",
+        "xch"
+    ],
+    "cocos islands": [
+        "cc",
+        "cck",
+        "科科斯"
+    ],
+    "colombia": [
+        "col"
+    ],
+    "comoros": [
+        "como"
+    ],
+    "congo brazzaville": [
+        "conb"
+    ],
+    "congo kinshasa": [
+        "cod"
+    ],
+    "cook islands": [],
+    "costa rica": [
+        "cstr",
+        "cr"
+    ],
+    "cote d'ivoire": [
+        "ivco",
+        "ci"
+    ],
+    "croatia": [
+        "hrv",
+        "hr"
+    ],
+    "cuba": [
+        "cu",
+        "cuba"
+    ],
+    "cyprus": [
+        "cypr",
+        "cy"
+    ],
+    "czechia": [
+        "czec",
+        "cz",
+        "ceki",
+        "ceko",
+        "céko",
+        "chek",
+        "chk",
+        "çeki",
+        "чех",
+        "чехи",
+        "تشيك",
+        "چک",
+        "چکیا",
+        "ܬܫܝܟ",
+        "เช็ก",
+        "ቼቺያ",
+        "ឆែក",
+        "チェコ",
+        "捷克",
+        "체코"
+    ],
+    "democratic republic of the congo": [
+        "cd",
+        "rdc",
+        "zair",
+        "zyyr",
+        "заир",
+        "زئیر",
+        "ኮንጎ",
+        "ザイール",
+        "扎伊尔"
+    ],
+    "denmark": [
+        "den",
+        "dk"
+    ],
+    "djibouti": [
+        "dj",
+        "dji",
+        "jib",
+        "ジブチ市",
+        "吉布地市",
+        "吉布提城",
+        "지부티"
+    ],
+    "dominica": [
+        "domn",
+        "dm"
+    ],
+    "dominican republic": [
+        "domr",
+        "dr",
+        "do",
+        "多明尼加",
+        "多米尼加"
+    ],
+    "ecuador": [
+        "ecua",
+        "ec"
+    ],
+    "egypt": [
+        "egyp",
+        "eg"
+    ],
+    "el salvador": [
+        "elsl",
+        "sv"
+    ],
+    "equatorial guinea": [
+        "egn",
+        "gq"
+    ],
+    "eritrea": [
+        "eri",
+        "er"
+    ],
+    "estonia": [
+        "est",
+        "ee"
+    ],
+    "eswatini": [
+        "史瓦濟蘭",
+        "斯威士兰"
+    ],
+    "ethiopia": [
+        "eth",
+        "et"
+    ],
+    "falkland islands": [
+        "fk"
+    ],
+    "faroe islands": [
+        "fo",
+        "法罗群岛",
+        "法羅群島",
+        "페로제도"
+    ],
+    "fiji": [
+        "fiji",
+        "fj"
+    ],
+    "finland": [
+        "fin",
+        "fi"
+    ],
+    "france": [
+        "fr",
+        "fran"
+    ],
+    "french polynesia": [
+        "pf"
+    ],
+    "gabon": [
+        "gabn",
+        "ga"
+    ],
+    "gambia": [
+        "gm",
+        "gam",
+        "ጋምቢያ",
+        "ហគប",
+        "ガンビア",
+        "冈比亚",
+        "甘比亞",
+        "감비아"
+    ],
+    "georgia": [
+        "ge",
+        "geo",
+        "гүрж",
+        "ຈເຈຍ",
+        "ཇར་ཇ",
+        "ጆርጂያ",
+        "グルジア",
+        "喬治亞",
+        "格魯吉亞",
+        "格鲁吉亚",
+        "그루지아",
+        "그루지야",
+        "조지아"
+    ],
+    "germany": [
+        "ger",
+        "de"
+    ],
+    "ghana": [
+        "ghan",
+        "gh"
+    ],
+    "gibraltar": [
+        "gi",
+        "gib",
+        "直布罗陀",
+        "直布羅陀",
+        "지브롤터"
+    ],
+    "greece": [
+        "grc",
+        "gr"
+    ],
+    "greenland": [
+        "gl",
+        "格陵兰",
+        "格陵蘭",
+        "그린란드",
+        "그린랜드"
+    ],
+    "grenada": [
+        "gren",
+        "gd"
+    ],
+    "guadeloupe": [
+        "gp"
+    ],
+    "guam": [
+        "gu",
+        "gum",
+        "guam",
+        "guâm",
+        "gvam",
+        "gwam",
+        "quam",
+        "guam",
+        "gvam",
+        "gwam",
+        "kwm",
+        "гуам",
+        "גואם",
+        "غوام",
+        "ګwam",
+        "ګوام",
+        "گوام",
+        "गुआम",
+        "ਗੁਆਮ",
+        "ගවාම",
+        "กวม",
+        "ກວາມ",
+        "ጉዋም",
+        "ហគា",
+        "グアム",
+        "关岛",
+        "關島",
+        "괌"
+    ],
+    "guatemala": [
+        "guat",
+        "gt"
+    ],
+    "guernsey": [
+        "gg",
+        "gci",
+        "根西岛",
+        "건지 섬"
+    ],
+    "guinea": [
+        "gnea",
+        "gn"
+    ],
+    "guinea bissau": [
+        "guib",
+        "gw"
+    ],
+    "guyana": [
+        "guy",
+        "gy"
+    ],
+    "haiti": [
+        "hat",
+        "ht"
+    ],
+    "holy see": [
+        "vat",
+        "va"
+    ],
+    "honduras": [
+        "hond",
+        "hn"
+    ],
+    "hong kong": [
+        "hk",
+        "hkg",
+        "hoko",
+        "हङकङ",
+        "হংকং",
+        "ହଂକଂ",
+        "ហងកង",
+        "香港",
+        "홍콩"
+    ],
+    "hungary": [
+        "hu",
+        "mgr",
+        "mjr",
+        "hung",
+        "ѫгри",
+        "مجر",
+        "ܡܓܪ",
+        "ሀንጋሪ",
+        "ꮂꮒꭶꮅ",
+        "ហងគរ",
+        "匈牙利",
+        "헝가리"
+    ],
+    "iceland": [
+        "icld",
+        "is"
+    ],
+    "india": [
+        "imd",
+        "in"
+    ],
+    "indonesia": [
+        "idsa",
+        "id"
+    ],
+    "iran": [
+        "iq",
+        "iran",
+        "īrān"
+    ],
+    "iraq": [
+        "iraq"
+    ],
+    "ireland": [
+        "eire",
+        "ie",
+        "iiri",
+        "ire",
+        "éire",
+        "愛爾蘭",
+        "爱尔兰",
+        "아일랜드"
+    ],
+    "isle of man": [
+        "im",
+        "iom",
+        "man",
+        "mann",
+        "men",
+        "moen",
+        "mön",
+        "мен",
+        "マン島",
+        "曼岛",
+        "曼島",
+        "马恩岛",
+        "맨 섬",
+        "맨섬"
+    ],
+    "israel": [
+        "isrl",
+        "il"
+    ],
+    "italy": [
+        "itly",
+        "it"
+    ],
+    "jamaica": [
+        "jam",
+        "jm"
+    ],
+    "japan": [
+        "jp",
+        "hapo",
+        "hapõ",
+        "japo",
+        "japu",
+        "japó",
+        "zapɔ",
+        "jpan",
+        "ypn",
+        "jpn",
+        "япон",
+        "יפן",
+        "جپان",
+        "ژاپن",
+        "ܝܦܢ",
+        "जपान",
+        "ਜਪਾਨ",
+        "ຍປນ",
+        "ཇ་པན",
+        "ጃፓን",
+        "ꮳꮹꮒꮟ",
+        "ᓃᑉᐊᓐ",
+        "ជបន",
+        "ᨍᨛᨄ",
+        "日本",
+        "ꏝꀪ",
+        "일본"
+    ],
+    "jersey": [
+        "je",
+        "jer",
+        "澤西島",
+        "저지 섬"
+    ],
+    "jordan": [
+        "jord",
+        "jo"
+    ],
+    "kazakhstan": [
+        "kaz",
+        "kz"
+    ],
+    "kenya": [
+        "keny",
+        "ke"
+    ],
+    "kiribati": [
+        "kiri",
+        "ki"
+    ],
+    "kosovo": [],
+    "kuwait": [
+        "kuwt",
+        "ku"
+    ],
+    "kyrgyzstan": [
+        "kgz",
+        "kg"
+    ],
+    "laos": [
+        "laos",
+        "la"
+    ],
+    "latvia": [
+        "latv",
+        "lv"
+    ],
+    "lebanon": [
+        "lb",
+        "lebn",
+        "liba",
+        "libá",
+        "lbnn",
+        "ܠܒܢܢ",
+        "ሊባኖስ",
+        "លបង",
+        "レバノン",
+        "黎巴嫩",
+        "레바논"
+    ],
+    "lesotho": [
+        "les",
+        "ls"
+    ],
+    "liberia": [
+        "libr",
+        "lr"
+    ],
+    "libya": [
+        "libi",
+        "libí",
+        "livi",
+        "lbya",
+        "lwb",
+        "lyby",
+        "ly",
+        "ливи",
+        "לוב",
+        "لبيا",
+        "لیبی",
+        "ܠܘܒܐ",
+        "ລເບຍ",
+        "ሊቢያ",
+        "លប",
+        "リビア",
+        "利比亚",
+        "利比亞",
+        "리비아"
+    ],
+    "liechtenstein": [
+        "lcht",
+        "li"
+    ],
+    "lithuania": [
+        "lith",
+        "lt"
+    ],
+    "luxembourg": [
+        "lu",
+        "lxm",
+        "lux",
+        "盧森堡城",
+        "盧森堡市"
+    ],
+    "macau": [
+        "mac",
+        "mo"
+    ],
+    "macedonia": [
+        "mkd",
+        "mk"
+    ],
+    "madagascar": [
+        "madg",
+        "mg"
+    ],
+    "malawi": [
+        "malw",
+        "mw"
+    ],
+    "malaysia": [
+        "my",
+        "mlas",
+        "ማሌዢያ",
+        "馬來西亞",
+        "马来西亚"
+    ],
+    "maldives": [
+        "mldv",
+        "mv"
+    ],
+    "mali": [
+        "mali",
+        "ml"
+    ],
+    "malta": [
+        "mt",
+        "mlta",
+        "malt",
+        "mlth",
+        "מלטה",
+        "مالت",
+        "マルタ島",
+        "馬耳他島",
+        "몰타 섬"
+    ],
+    "marshall islands": [
+        "mh"
+    ],
+    "martinique": [
+        "mq"
+    ],
+    "mauritania": [
+        "maur",
+        "mr"
+    ],
+    "mauritius": [
+        "mrts",
+        "mu"
+    ],
+    "mayotte": [
+        "yt",
+        "mywt",
+        "מיוט",
+        "මයොට",
+        "མ་ཡཊ",
+        "ሜይኦቴ",
+        "មាយត",
+        "マヨット",
+        "馬約特島",
+        "马约特",
+        "마요트",
+        "마요티"
+    ],
+    "mexico": [
+        "mex",
+        "mx"
+    ],
+    "moldova": [
+        "mld",
+        "md"
+    ],
+    "monaco": [
+        "mc",
+        "mon",
+        "mcm",
+        "모나코"
+    ],
+    "mongolia": [
+        "mn",
+        "mool",
+        "mong",
+        "моол",
+        "モンゴル",
+        "蒙古",
+        "蒙古国",
+        "蒙古國",
+        "몽골"
+    ],
+    "montenegro": [
+        "me",
+        "黑山"
+    ],
+    "montserrat": [
+        "mont",
+        "ms"
+    ],
+    "morocco": [
+        "moro",
+        "ma"
+    ],
+    "mozambique": [
+        "moz",
+        "mz"
+    ],
+    "namibia": [
+        "namb",
+        "na"
+    ],
+    "nauru": [
+        "nr",
+        "nau",
+        "naru",
+        "nárú",
+        "naru",
+        "nwrw",
+        "نؤرو",
+        "نورو",
+        "नौरु",
+        "नौरू",
+        "નૌરુ",
+        "நௌரு",
+        "నౌరు",
+        "ನೌರು",
+        "നൗറു",
+        "നൗറൂ",
+        "ນາອຣ",
+        "ናኡሩ",
+        "ናውሩ",
+        "ណរ",
+        "ណូរូ",
+        "ナウル",
+        "瑙魯",
+        "瑙鲁",
+        "諾魯",
+        "나우루"
+    ],
+    "nepal": [
+        "nep",
+        "np"
+    ],
+    "netherlands": [
+        "neth",
+        "nl"
+    ],
+    "netherlands antilles": [
+        "neta",
+        "an"
+    ],
+    "new caledonia": [
+        "ncal",
+        "nc"
+    ],
+    "new zealand": [
+        "nz",
+        "nzld",
+        "新西兰",
+        "紐西蘭",
+        "뉴질랜드"
+    ],
+    "nicaragua": [
+        "nic",
+        "ni"
+    ],
+    "niger": [
+        "nir",
+        "ne"
+    ],
+    "nigeria": [
+        "nra",
+        "ng"
+    ],
+    "niue": [
+        "nu",
+        "iue",
+        "nija",
+        "nioe",
+        "nioé",
+        "niue",
+        "niui",
+        "niuo",
+        "niuè",
+        "niué",
+        "niuē",
+        "niw",
+        "niwe",
+        "niyu",
+        "niûe",
+        "nju",
+        "nyue",
+        "nyué",
+        "ni'u",
+        "niue",
+        "niyu",
+        "nu'u",
+        "nwwy",
+        "nyw",
+        "nyww",
+        "nywy",
+        "nyyw",
+        "ниуе",
+        "ниуэ",
+        "ніуе",
+        "ніуэ",
+        "нія",
+        "ניאו",
+        "نووي",
+        "نيوي",
+        "نیئو",
+        "نیوو",
+        "نیوٗ",
+        "ނީއު",
+        "नीयू",
+        "নিউ",
+        "নুউ",
+        "ਨਿਊਏ",
+        "ਨਿਯੂ",
+        "નીયુ",
+        "ନିଉ",
+        "நியூ",
+        "నియూ",
+        "ನಿಯು",
+        "නියූ",
+        "ນອເອ",
+        "ნიუე",
+        "ኒኡይ",
+        "ណៀ",
+        "ニウエ",
+        "ニウエ島",
+        "紐埃",
+        "紐埃島",
+        "纽埃",
+        "니우에"
+    ],
+    "norfolk island": [
+        "nlk",
+        "诺福克岛",
+        "노퍽 섬"
+    ],
+    "north korea": [
+        "prk",
+        "kp"
+    ],
+    "north macedonia": [
+        "arym",
+        "北馬其頓",
+        "北马其顿"
+    ],
+    "northern mariana islands": [],
+    "norway": [
+        "norw",
+        "no"
+    ],
+    "oman": [
+        "oman",
+        "om"
+    ],
+    "pakistan": [
+        "pkst",
+        "pk"
+    ],
+    "palau": [
+        "pala",
+        "pw"
+    ],
+    "panama": [
+        "pa",
+        "pan",
+        "pty",
+        "巴拿馬城"
+    ],
+    "papua new guinea": [
+        "png",
+        "pg"
+    ],
+    "paraguay": [
+        "para",
+        "py"
+    ],
+    "peru": [
+        "peru",
+        "pe"
+    ],
+    "philippines": [
+        "phil",
+        "ph"
+    ],
+    "pitcairn islands": [
+        "pitc",
+        "pn"
+    ],
+    "poland": [
+        "pol",
+        "pl"
+    ],
+    "portugal": [
+        "port",
+        "pt"
+    ],
+    "puerto rico": [
+        "波多黎各"
+    ],
+    "qatar": [
+        "qtar",
+        "qa"
+    ],
+    "republic of the congo": [
+        "cg",
+        "コンゴ",
+        "刚果",
+        "콩고"
+    ],
+    "reunion": [
+        "re"
+    ],
+    "romania": [
+        "ro",
+        "rom",
+        "ሮማንያ",
+        "ሮሜኒያ",
+        "ꮆꮉꮒꮿ",
+        "រមាន",
+        "罗马尼亚",
+        "羅馬尼亞",
+        "루마니아"
+    ],
+    "russia": [
+        "rus",
+        "ru"
+    ],
+    "rwanda": [
+        "rwnd",
+        "rw"
+    ],
+    "saint barthelemy": [
+        "sbh",
+        "聖巴瑟米"
+    ],
+    "saint helena": [
+        "shel",
+        "hle",
+        "sh"
+    ],
+    "saint kitts and nevis": [
+        "stcn",
+        "kn"
+    ],
+    "saint lucia": [
+        "lc",
+        "slca",
+        "圣卢西亚",
+        "聖露西亞"
+    ],
+    "saint martin": [
+        "mf",
+        "sfg"
+    ],
+    "saint pierre and miquelon": [
+        "pm"
+    ],
+    "saint vincent and the grenadines": [
+        "stvn",
+        "vc"
+    ],
+    "samoa": [
+        "wsam",
+        "ws"
+    ],
+    "san marino": [
+        "sm",
+        "smar",
+        "sai",
+        "聖馬力諾",
+        "산마리노"
+    ],
+    "sao tome and principe": [
+        "stpr",
+        "st"
+    ],
+    "saudi arabia": [
+        "sarb",
+        "sa"
+    ],
+    "senegal": [
+        "seng",
+        "sn"
+    ],
+    "serbia": [
+        "rs",
+        "sebi",
+        "sèbi",
+        "ሰርቢያ",
+        "ሰርብያ",
+        "ꮢꮘꮿ",
+        "សែប",
+        "セルビア",
+        "塞尔维亚",
+        "塞爾維亞",
+        "세르비아"
+    ],
+    "serbia and montenegro": [
+        "cs",
+        "scg"
+    ],
+    "seychelles": [
+        "seyc",
+        "sc"
+    ],
+    "sierra leone": [
+        "sleo",
+        "sl"
+    ],
+    "singapore": [
+        "sg",
+        "sing",
+        "sin",
+        "新加坡",
+        "星架坡",
+        "싱가포르",
+        "싱가폴"
+    ],
+    "sint maarten": [
+        "sx",
+        "sxm",
+        "圣马丁岛"
+    ],
+    "slovakia": [
+        "svk",
+        "sk"
+    ],
+    "slovenia": [
+        "svn",
+        "si"
+    ],
+    "solomon islands": [
+        "sb",
+        "slmn",
+        "솔로몬"
+    ],
+    "somalia": [
+        "so",
+        "soma",
+        "ሱማሌ",
+        "ሶማሊያ",
+        "ソマリア",
+        "索馬利亞",
+        "索馬里",
+        "索马里",
+        "소말리아"
+    ],
+    "south africa": [
+        "safr",
+        "za"
+    ],
+    "south georgia and the south sandwich islands": [],
+    "south korea": [
+        "kor",
+        "kr"
+    ],
+    "south sudan": [
+        "南苏丹",
+        "南蘇丹",
+        "남수단"
+    ],
+    "spain": [
+        "spn",
+        "esp",
+        "es"
+    ],
+    "sri lanka": [
+        "srl",
+        "lk"
+    ],
+    "sudan": [
+        "suda",
+        "sd"
+    ],
+    "suriname": [
+        "surm",
+        "sr"
+    ],
+    "svalbard and jan mayen": [
+        "sj",
+        "스발바르"
+    ],
+    "swaziland": [
+        "szld",
+        "sz"
+    ],
+    "sweden": [
+        "swdn",
+        "se"
+    ],
+    "switzerland": [
+        "swtz",
+        "ch",
+        "suis",
+        "swys",
+        "سویس",
+        "សវស",
+        "スイス",
+        "瑞士",
+        "스위스"
+    ],
+    "syria": [
+        "syr",
+        "sy"
+    ],
+    "taiwan": [
+        "tw",
+        "twan",
+        "台灣"
+    ],
+    "tajikistan": [
+        "tjk",
+        "tj"
+    ],
+    "tanzania": [
+        "tazn",
+        "tz"
+    ],
+    "thailand": [
+        "thai",
+        "th"
+    ],
+    "timor-leste": [
+        "tmor",
+        "tl"
+    ],
+    "togo": [
+        "togo",
+        "tg"
+    ],
+    "tokelau": [],
+    "tonga": [
+        "tong",
+        "to"
+    ],
+    "trinidad and tobago": [
+        "trin",
+        "tt"
+    ],
+    "tunisia": [
+        "tnsa",
+        "tn"
+    ],
+    "turkey": [
+        "trky",
+        "tr"
+    ],
+    "turkmenistan": [
+        "tkm",
+        "tm"
+    ],
+    "turks and caicos islands": [
+        "tcis",
+        "tc"
+    ],
+    "tuvalu": [
+        "tv",
+        "tuv",
+        "ຕວາລ",
+        "ቱቫሉ",
+        "ទវាល",
+        "ツバル",
+        "吐瓦魯",
+        "图瓦卢",
+        "圖瓦盧",
+        "투발루"
+    ],
+    "uganda": [
+        "ugan",
+        "ug"
+    ],
+    "ukraine": [
+        "ua",
+        "ukr",
+        "ዩክሬን",
+        "乌克兰",
+        "烏克蘭"
+    ],
     "united arab emirates": [
         "oaeh",
         "uae",
         "ae",
-        "\u043e\u0430\u044d",
-        "\u963f\u8054\u914b"
+        "оаэ",
+        "阿联酋"
     ],
     "united kingdom": [
         "uk",
@@ -15,860 +1337,11 @@
         "g.b",
         "grbr"
     ],
-    "afghanistan": ["afgh", "af"],
-    "albania": ["alb","al"],
-    "antigua and barbuda": ["anti","ag"],
-    "algeria": ["algr","dz"],
-    "andorra": ["ando","ad"],
-    "australia":["astl", "au"],
-    "austria":["aust", "at"],
-    "azerbaijan": ["azr", "az"],
-    "angola":["ao"],
-    "anguilla": [
-        "axa",
-        "angu",
-        "ai",
-        "\u30a2\u30f3\u30ae\u30e9",
-        "\u5b89\u572d\u62c9",
-        "\uc575\uadc8\ub77c"
-    ],
-    "armenia": ["arm", "am"],
-    "antarctica": [
-        "aq",
-        "\u5357\u6781\u6d32",
-        "\u5357\u6975",
-        "\u5357\u6975\u6d32"
-    ],
-    "argentina": ["arg", "ar"],
-    "samoa": ["wsam","ws"],
-    "american samoa": ["as"],
-    "aruba": [
-        "aw",
-        "arb",
-        "\u0d05\u0d31\u0d41\u0d2c",
-        "\u0d05\u0d31\u0d42\u0d2c",
-        "\u0d85\u0dbb\u0db6\u0dcf",
-        "\u12a0\u1229\u1263",
-        "\u12a3\u1229\u1263",
-        "\u30a2\u30eb\u30d0",
-        "\u30a2\u30eb\u30d0\u5cf6",
-        "\u963f\u9b6f\u5df4",
-        "\u963f\u9c81\u5df4",
-        "\uc544\ub8e8\ubc14"
-    ],
-    "aland islands": ["ax"],
-    "bahamas": ["bama", "bs"],
-    "bosnia and herzegovina": [
-        "bq",
-        "bih",
-        "\u6ce2\u65af\u5c3c\u4e9e",
-        "\u6ce2\u9ed1",
-        "\ubcf4\uc2a4\ub2c8\uc544"
-    ],
-    "botswana":["bot","bw"],
-    "brazil":["brzl", "br"],
-    "brunei":["brni","bn"],
-    "bulgaria":["bulg", "bg"],
-    "barbados": ["brdo","bb"],
-    "burma":["burm"],
-    "burundi":["brnd","bi"],
-    "bangladesh": [
-        "bd",
-        "bang",
-        "\u5b5f\u52a0\u62c9",
-        "\u5b5f\u52a0\u62c9\u56fd",
-        "\u5b5f\u52a0\u62c9\u570b"
-    ],
-    "burkina faso": ["burk","bf"],
-    "bahrain": [
-        "bh",
-        "bahr",
-        "awal",
-        "aw\u0101l"
-    ],
-    "belarus": ["bys","by"],
-    "belgium":["belg","be"],
-    "benin": ["benn", "bj"],
-    "saint barthelemy": [
-        "sbh",
-        "\u8056\u5df4\u745f\u7c73"
-    ],
-    "bhutan":["bhu","bt"],
-    "bolivia":["bol","bo"],
-    "bermuda": [
-        "bm",
-        "berm",
-        "bda",
-        "\u1264\u122d\u1219\u12f3",
-        "\u767e\u6155\u5927",
-        "\u767e\u6155\u9054",
-        "\ubc84\ubba4\ub2e4"
-    ],
-    "bouvet island": [
-        "bv",
-        "buve",
-        "\u10d1\u10e3\u10d5\u10d4",
-        "\u30d6\u30fc\u30d9\u5cf6",
-        "\u5e03\u5a01\u5cf6",
-        "\u5e03\u7ef4\u5c9b",
-        "\u5e03\u7ef4\u7279\u5c9b",
-        "\u5e03\u97e6\u5c9b",
-        "\ubd80\ubca0 \uc12c",
-        "\ubd80\ubca0\uc12c"
-    ],
-    "belize": [
-        "bz",
-        "blz",
-        "blyz",
-        "\u05d1\u05dc\u05d9\u05d6",
-        "\u0628\u0644\u064a\u0632",
-        "\u0628\u0644\u06cc\u0632",
-        "\u0ec0\u0e9a\u0ea5\u0e8a",
-        "\u0f56\u0f0b\u0f63\u0f5b",
-        "\u1260\u120a\u12dd",
-        "\u1264\u120a\u12d8",
-        "\u1264\u120a\u12dd",
-        "\u1794\u17c1\u179b",
-        "\u1794\u17c1\u179b\u17b8",
-        "\u30d9\u30ea\u30fc\u30ba",
-        "\u4f2f\u5229\u5179",
-        "\u4f2f\u5229\u8332",
-        "\u8c9d\u91cc\u65af",
-        "\ubca8\ub9ac\uc988"
-    ],
-    "cambodia":["cbda","kh"],
-    "cameroon":["cmrn","cm"],
-    "cape verde":["cavi","cv"],
-    "canada": [
-        "ca",
-        "can",
-        "knda",
-        "qndh",
-        "\u05e7\u05e0\u05d3\u05d4",
-        "\u0643\u0646\u062f\u0627",
-        "\u0b95\u0ba9\u0b9f\u0bbe",
-        "\u0d15\u0d3e\u0d28\u0d21",
-        "\u12ab\u1293\u12f3",
-        "\u30ab\u30ca\u30c0",
-        "\u52a0\u62ff\u5927",
-        "\uce90\ub098\ub2e4"
-    ],
-    "cocos islands": [
-        "cc",
-        "cck",
-        "\u79d1\u79d1\u65af"
-    ],
-    "democratic republic of the congo": [
-        "cd",
-        "rdc",
-        "zair",
-        "zyyr",
-        "\u0437\u0430\u0438\u0440",
-        "\u0632\u0626\u06cc\u0631",
-        "\u12ae\u1295\u130e",
-        "\u30b6\u30a4\u30fc\u30eb",
-        "\u624e\u4f0a\u5c14"
-    ],
-    "central african republic": ["cf",
-        "cafr",
-        "\u4e2d\u975e"
-    ],
-    "chad":["chad", "td"],
-    "chile":["chil", "cl"],
-    "china":["chin","cn"],
-    "republic of the congo": [
-        "cg",
-        "\u30b3\u30f3\u30b4",
-        "\u521a\u679c",
-        "\ucf69\uace0"
-    ],
-    "syria":["syr","sy"],
-    "switzerland": [
-        "swtz",
-        "ch",
-        "suis",
-        "swys",
-        "\u0633\u0648\u06cc\u0633",
-        "\u179f\u179c\u179f",
-        "\u30b9\u30a4\u30b9",
-        "\u745e\u58eb",
-        "\uc2a4\uc704\uc2a4"
-    ],
-    "cook islands": [],
-    "colombia": ["col"],
-    "comoros": ["como"],
-    "congo brazzaville": ["conb"],
-    "congo kinshasa":["cod"],
-    "costa rica":["cstr", "cr"],
-    "cote d'ivoire":["ivco", "ci"],
-    "croatia":["hrv","hr"],
-
-    "serbia and montenegro": [
-        "cs",
-        "scg"
-    ],
-    "cuba": [
-        "cu",
-        "cuba"
-    ],
-    "christmas island": [
-        "cx",
-        "xch"
-    ],
-    "cyprus": ["cypr", "cy"],
-    "czechia": [
-        "czec",
-        "cz",
-        "ceki",
-        "ceko",
-        "c\u00e9ko",
-        "chek",
-        "chk",
-        "\u00e7eki",
-        "\u0447\u0435\u0445",
-        "\u0447\u0435\u0445\u0438",
-        "\u062a\u0634\u064a\u0643",
-        "\u0686\u06a9",
-        "\u0686\u06a9\u06cc\u0627",
-        "\u072c\u072b\u071d\u071f",
-        "\u0e40\u0e0a\u0e47\u0e01",
-        "\u127c\u127a\u12eb",
-        "\u1786\u17c2\u1780",
-        "\u30c1\u30a7\u30b3",
-        "\u6377\u514b",
-        "\uccb4\ucf54"
-    ],
-    "djibouti": [
-        "dj",
-        "dji",
-        "jib",
-        "\u30b8\u30d6\u30c1\u5e02",
-        "\u5409\u5e03\u5730\u5e02",
-        "\u5409\u5e03\u63d0\u57ce",
-        "\uc9c0\ubd80\ud2f0"
-    ],
-    "denmark":["den","dk"],
-    "dominica": ["domn","dm"],
-    "dominican republic": [
-        "domr",
-        "dr",
-        "do",
-        "\u591a\u660e\u5c3c\u52a0",
-        "\u591a\u7c73\u5c3c\u52a0"
-    ],
-    "ecuador":["ecua","ec"],
-    "egypt":["egyp","eg"],
-    "equatorial guinea":["egn","gq"],
-    "eritrea":["eri", "er"],
-    "estonia":["est","ee"],
-    "ethiopia":["eth","et"],
-
-    "western sahara": [
-        "ssah",
-        "eh",
-        "rasd",
-        "\u897f\u30b5\u30cf\u30e9",
-        "\u897f\u6492\u54c8\u62c9",
-        "\uc11c\uc0ac\ud558\ub77c"
-    ],
-    "fiji":["fiji","fj"],
-    "finland":["fin", "fi"],
-    "falkland islands": ["fk"],
-    "faroe islands": [
-        "fo",
-        "\u6cd5\u7f57\u7fa4\u5c9b",
-        "\u6cd5\u7f85\u7fa4\u5cf6",
-        "\ud398\ub85c\uc81c\ub3c4"
-    ],
-    "france": ["fr","fran"],
-    "gabon": ["gabn","ga"],
-    "grenada": ["gren","gd"],
-    "germany": ["ger", "de"],
-    "ghana":["ghan", "gh"],
-    "greece":["grc","gr"],
-    "guatemala":["guat","gt"],
-    "guinea": ["gnea", "gn"],
-    "guinea bissau":["guib", "gw"],
-    "guyana":["guy", "gy"],
-    "georgia": [
-        "ge",
-        "geo",
-        "\u0433\u04af\u0440\u0436",
-        "\u0e88\u0ec0\u0e88\u0e8d",
-        "\u0f47\u0f62\u0f0b\u0f47",
-        "\u1306\u122d\u1302\u12eb",
-        "\u30b0\u30eb\u30b8\u30a2",
-        "\u55ac\u6cbb\u4e9e",
-        "\u683c\u9b6f\u5409\u4e9e",
-        "\u683c\u9c81\u5409\u4e9a",
-        "\uadf8\ub8e8\uc9c0\uc544",
-        "\uadf8\ub8e8\uc9c0\uc57c",
-        "\uc870\uc9c0\uc544"
-    ],
-    "guernsey": [
-        "gg",
-        "gci",
-        "\u6839\u897f\u5c9b",
-        "\uac74\uc9c0 \uc12c"
-    ],
-    "gibraltar": [
-        "gi",
-        "gib",
-        "\u76f4\u5e03\u7f57\u9640",
-        "\u76f4\u5e03\u7f85\u9640",
-        "\uc9c0\ube0c\ub864\ud130"
-    ],
-    "greenland": [
-        "gl",
-        "\u683c\u9675\u5170",
-        "\u683c\u9675\u862d",
-        "\uadf8\ub9b0\ub780\ub4dc",
-        "\uadf8\ub9b0\ub79c\ub4dc"
-    ],
-    "gambia": [
-        "gm",
-        "gam",
-        "\u130b\u121d\u1262\u12eb",
-        "\u17a0\u1782\u1794",
-        "\u30ac\u30f3\u30d3\u30a2",
-        "\u5188\u6bd4\u4e9a",
-        "\u7518\u6bd4\u4e9e",
-        "\uac10\ube44\uc544"
-    ],
-    "guadeloupe": ["gp"],
-    "south georgia and the south sandwich islands": [],
-    "guam": [
-        "gu",
-        "gum",
-        "guam",
-        "gu\u00e2m",
-        "gvam",
-        "gwam",
-        "quam",
-        "guam",
-        "gvam",
-        "gwam",
-        "kwm",
-        "\u0433\u0443\u0430\u043c",
-        "\u05d2\u05d5\u05d0\u05dd",
-        "\u063a\u0648\u0627\u0645",
-        "\u06abwam",
-        "\u06ab\u0648\u0627\u0645",
-        "\u06af\u0648\u0627\u0645",
-        "\u0917\u0941\u0906\u092e",
-        "\u0a17\u0a41\u0a06\u0a2e",
-        "\u0d9c\u0dc0\u0dcf\u0db8",
-        "\u0e01\u0e27\u0e21",
-        "\u0e81\u0ea7\u0eb2\u0ea1",
-        "\u1309\u12cb\u121d",
-        "\u17a0\u1782\u17b6",
-        "\u30b0\u30a2\u30e0",
-        "\u5173\u5c9b",
-        "\u95dc\u5cf6",
-        "\uad0c"
-    ],
-    "hong kong": [
-        "hk",
-        "hkg",
-        "hoko",
-        "\u0939\u0919\u0915\u0919",
-        "\u09b9\u0982\u0995\u0982",
-        "\u0b39\u0b02\u0b15\u0b02",
-        "\u17a0\u1784\u1780\u1784",
-        "\u9999\u6e2f",
-        "\ud64d\ucf69"
-    ],
-    "hungary": [
-        "hu",
-        "mgr",
-        "mjr",
-        "hung",
-        "\u046b\u0433\u0440\u0438",
-        "\u0645\u062c\u0631",
-        "\u0721\u0713\u072a",
-        "\u1200\u1295\u130b\u122a",
-        "\uab82\uab92\uab76\uab85",
-        "\u17a0\u1784\u1782\u179a",
-        "\u5308\u7259\u5229",
-        "\ud5dd\uac00\ub9ac"
-    ],
-    "haiti":["hat", "ht"],
-    "holy see":["vat","va"],
-    "honduras":["hond", "hn"],
-    "ireland": [
-        "eire",
-        "ie",
-        "iiri",
-        "ire",
-        "\u00e9ire",
-        "\u611b\u723e\u862d",
-        "\u7231\u5c14\u5170",
-        "\uc544\uc77c\ub79c\ub4dc"
-    ],
-    "isle of man": [
-        "im",
-        "iom",
-        "man",
-        "mann",
-        "men",
-        "moen",
-        "m\u00f6n",
-        "\u043c\u0435\u043d",
-        "\u30de\u30f3\u5cf6",
-        "\u66fc\u5c9b",
-        "\u66fc\u5cf6",
-        "\u9a6c\u6069\u5c9b",
-        "\ub9e8 \uc12c",
-        "\ub9e8\uc12c"
-    ],
-    "british indian ocean territory": [],
-    "iran": [
-        "iq",
-        "iran",
-        "\u012br\u0101n"
-    ],
-    "iceland": ["icld", "is"],
-    "india": ["imd", "in"],
-    "indonesia":["idsa","id"],
-    "iraq":["iraq"],
-    "israel":["isrl","il"],
-    "italy":["itly","it"],
-    "jersey": [
-        "je",
-        "jer",
-        "\u6fa4\u897f\u5cf6",
-        "\uc800\uc9c0 \uc12c"
-    ],
-    "jamaica": ["jam","jm"],
-    "japan": [
-        "jp",
-        "hapo",
-        "hap\u00f5",
-        "japo",
-        "japu",
-        "jap\u00f3",
-        "zap\u0254",
-        "jpan",
-        "ypn",
-        "jpn",
-        "\u044f\u043f\u043e\u043d",
-        "\u05d9\u05e4\u05df",
-        "\u062c\u067e\u0627\u0646",
-        "\u0698\u0627\u067e\u0646",
-        "\u071d\u0726\u0722",
-        "\u091c\u092a\u093e\u0928",
-        "\u0a1c\u0a2a\u0a3e\u0a28",
-        "\u0e8d\u0e9b\u0e99",
-        "\u0f47\u0f0b\u0f54\u0f53",
-        "\u1303\u1353\u1295",
-        "\uabb3\uabb9\uab92\uab9f",
-        "\u14c3\u1449\u140a\u14d0",
-        "\u1787\u1794\u1793",
-        "\u1a0d\u1a1b\u1a04",
-        "\u65e5\u672c",
-        "\ua3dd\ua02a",
-        "\uc77c\ubcf8"
-    ],
-    "jordan":["jord","jo"],
-    "kyrgyzstan": ["kgz","kg"],
-    "cayman islands": ["cayi", "ky"],
-    "kazakhstan": ["kaz","kz"],
-    "kenya":["keny","ke"],
-    "kiribati":["kiri","ki"],
-    "north korea": ["prk","kp"],
-    "south korea": ["kor","kr"],
-    "kuwait":["kuwt","ku"],
-    "laos":["laos","la"],
-    "latvia":["latv","lv"],
-    "lesotho":["les","ls"],
-    "liberia":["libr","lr"],
-    "lebanon": [
-        "lb",
-        "lebn",
-        "liba",
-        "lib\u00e1",
-        "lbnn",
-        "\u0720\u0712\u0722\u0722",
-        "\u120a\u1263\u1296\u1235",
-        "\u179b\u1794\u1784",
-        "\u30ec\u30d0\u30ce\u30f3",
-        "\u9ece\u5df4\u5ae9",
-        "\ub808\ubc14\ub17c"
-    ],
-    "saint lucia": [
-        "lc",
-        "slca",
-        "\u5723\u5362\u897f\u4e9a",
-        "\u8056\u9732\u897f\u4e9e"
-    ],
-    "sri lanka": ["srl","lk"],
-    "liechtenstein":["lcht","li"],
-    "lithuania":["lith","lt"],
-    "luxembourg": [
-        "lu",
-        "lxm",
-        "lux",
-        "\u76e7\u68ee\u5821\u57ce",
-        "\u76e7\u68ee\u5821\u5e02"
-    ],
-    "libya": [
-        "libi",
-        "lib\u00ed",
-        "livi",
-        "lbya",
-        "lwb",
-        "lyby",
-        "ly",
-        "\u043b\u0438\u0432\u0438",
-        "\u05dc\u05d5\u05d1",
-        "\u0644\u0628\u064a\u0627",
-        "\u0644\u06cc\u0628\u06cc",
-        "\u0720\u0718\u0712\u0710",
-        "\u0ea5\u0ec0\u0e9a\u0e8d",
-        "\u120a\u1262\u12eb",
-        "\u179b\u1794",
-        "\u30ea\u30d3\u30a2",
-        "\u5229\u6bd4\u4e9a",
-        "\u5229\u6bd4\u4e9e",
-        "\ub9ac\ube44\uc544"
-    ],
-    "macau":["mac","mo"],
-    "macedonia":["mkd","mk"],
-    "madagascar":["madg","mg"],
-    "monaco": [
-        "mc",
-        "mon",
-        "mcm",
-        "\ubaa8\ub098\ucf54"
-    ],
-    "montenegro": [
-        "me",
-        "\u9ed1\u5c71"
-    ],
-    "saint martin": [
-        "mf",
-        "sfg"
-    ],
-    "marshall islands": ["mh"],
-    "north macedonia": [
-        "arym",
-        "\u5317\u99ac\u5176\u9813",
-        "\u5317\u9a6c\u5176\u987f"
-    ],
-    "mongolia": [
-        "mn",
-        "mool",
-        "mong",
-        "\u043c\u043e\u043e\u043b",
-        "\u30e2\u30f3\u30b4\u30eb",
-        "\u8499\u53e4",
-        "\u8499\u53e4\u56fd",
-        "\u8499\u53e4\u570b",
-        "\ubabd\uace8"
-    ],
-    "northern mariana islands": [],
-    "martinique": ["mq"],
-    "montserrat": ["mont","ms"],
-    "morocco":["moro","ma"],
-    "mozambique":["moz","mz"],
-    "malta": [
-        "mt",
-        "mlta",
-        "malt",
-        "mlth",
-        "\u05de\u05dc\u05d8\u05d4",
-        "\u0645\u0627\u0644\u062a",
-        "\u30de\u30eb\u30bf\u5cf6",
-        "\u99ac\u8033\u4ed6\u5cf6",
-        "\ubab0\ud0c0 \uc12c"
-    ],
-    "maldives":["mldv","mv"],
-    "mali":["mali","ml"],
-    "mauritania":["maur","mr"],
-    "mauritius":["mrts","mu"],
-    "malawi": ["malw","mw"],
-    "mexico": ["mex","mx"],
-    "moldova": ["mld","md"],
-    "malaysia": [
-        "my",
-        "mlas",
-        "\u121b\u120c\u12e2\u12eb",
-        "\u99ac\u4f86\u897f\u4e9e",
-        "\u9a6c\u6765\u897f\u4e9a"
-    ],
-    "new caledonia": ["ncal","nc"],
-    "norfolk island": [
-        "nlk",
-        "\u8bfa\u798f\u514b\u5c9b",
-        "\ub178\ud37d \uc12c"
-    ],
-    "namibia":["namb","na"],
-    "netherlands":["neth","nl"],
-    "netherlands antilles": ["neta","an"],
-    "nicaragua":["nic","ni"],
-    "niger":["nir","ne"],
-    "nigeria":["nra","ng"],
-    "norway":["norw","no"],
-    "nepal": ["nep","np"],
-    "nauru": [
-        "nr",
-        "nau",
-        "naru",
-        "n\u00e1r\u00fa",
-        "naru",
-        "nwrw",
-        "\u0646\u0624\u0631\u0648",
-        "\u0646\u0648\u0631\u0648",
-        "\u0928\u094c\u0930\u0941",
-        "\u0928\u094c\u0930\u0942",
-        "\u0aa8\u0acc\u0ab0\u0ac1",
-        "\u0ba8\u0bcc\u0bb0\u0bc1",
-        "\u0c28\u0c4c\u0c30\u0c41",
-        "\u0ca8\u0ccc\u0cb0\u0cc1",
-        "\u0d28\u0d57\u0d31\u0d41",
-        "\u0d28\u0d57\u0d31\u0d42",
-        "\u0e99\u0eb2\u0ead\u0ea3",
-        "\u1293\u12a1\u1229",
-        "\u1293\u12cd\u1229",
-        "\u178e\u179a",
-        "\u178e\u17bc\u179a\u17bc",
-        "\u30ca\u30a6\u30eb",
-        "\u7459\u9b6f",
-        "\u7459\u9c81",
-        "\u8afe\u9b6f",
-        "\ub098\uc6b0\ub8e8"
-    ],
-    "niue": [
-        "nu",
-        "iue",
-        "nija",
-        "nioe",
-        "nio\u00e9",
-        "niue",
-        "niui",
-        "niuo",
-        "niu\u00e8",
-        "niu\u00e9",
-        "niu\u0113",
-        "niw",
-        "niwe",
-        "niyu",
-        "ni\u00fbe",
-        "nju",
-        "nyue",
-        "nyu\u00e9",
-        "ni'u",
-        "niue",
-        "niyu",
-        "nu'u",
-        "nwwy",
-        "nyw",
-        "nyww",
-        "nywy",
-        "nyyw",
-        "\u043d\u0438\u0443\u0435",
-        "\u043d\u0438\u0443\u044d",
-        "\u043d\u0456\u0443\u0435",
-        "\u043d\u0456\u0443\u044d",
-        "\u043d\u0456\u044f",
-        "\u05e0\u05d9\u05d0\u05d5",
-        "\u0646\u0648\u0648\u064a",
-        "\u0646\u064a\u0648\u064a",
-        "\u0646\u06cc\u0626\u0648",
-        "\u0646\u06cc\u0648\u0648",
-        "\u0646\u06cc\u0648\u0657",
-        "\u0782\u07a9\u0787\u07aa",
-        "\u0928\u0940\u092f\u0942",
-        "\u09a8\u09bf\u0989",
-        "\u09a8\u09c1\u0989",
-        "\u0a28\u0a3f\u0a0a\u0a0f",
-        "\u0a28\u0a3f\u0a2f\u0a42",
-        "\u0aa8\u0ac0\u0aaf\u0ac1",
-        "\u0b28\u0b3f\u0b09",
-        "\u0ba8\u0bbf\u0baf\u0bc2",
-        "\u0c28\u0c3f\u0c2f\u0c42",
-        "\u0ca8\u0cbf\u0caf\u0cc1",
-        "\u0db1\u0dd2\u0dba\u0dd6",
-        "\u0e99\u0ead\u0ec0\u0ead",
-        "\u10dc\u10d8\u10e3\u10d4",
-        "\u1292\u12a1\u12ed",
-        "\u178e\u17c0",
-        "\u30cb\u30a6\u30a8",
-        "\u30cb\u30a6\u30a8\u5cf6",
-        "\u7d10\u57c3",
-        "\u7d10\u57c3\u5cf6",
-        "\u7ebd\u57c3",
-        "\ub2c8\uc6b0\uc5d0"
-    ],
-    "new zealand": [
-        "nz",
-        "nzld",
-        "\u65b0\u897f\u5170",
-        "\u7d10\u897f\u862d",
-        "\ub274\uc9c8\ub79c\ub4dc"
-    ],
-    "oman":["oman","om"],
-    "panama": [
-        "pa",
-        "pan",
-        "pty",
-        "\u5df4\u62ff\u99ac\u57ce"
-    ],
-    "papua new guinea": ["png","pg"],
-    "paraguay":["para","py"],
-    "peru":["peru","pe"],
-    "french polynesia": ["pf"],
-    "philippines": ["phil","ph"],
-    "pitcairn islands": ["pitc","pn"],
-    "poland":["pol","pl"],
-    "pakistan": ["pkst", "pk"],
-    "palau":["pala","pw"],
-    "saint pierre and miquelon": ["pm"],
-    "puerto rico": [
-        "\u6ce2\u591a\u9ece\u5404"
-    ],
-    "portugal": ["port","pt"],
-    "qatar": ["qtar","qa"],
-    "reunion": ["re"],
-    "romania": [
-        "ro",
-        "rom",
-        "\u122e\u121b\u1295\u12eb",
-        "\u122e\u121c\u1292\u12eb",
-        "\uab86\uab89\uab92\uabbf",
-        "\u179a\u1798\u17b6\u1793",
-        "\u7f57\u9a6c\u5c3c\u4e9a",
-        "\u7f85\u99ac\u5c3c\u4e9e",
-        "\ub8e8\ub9c8\ub2c8\uc544"
-    ],
-    "russia": ["rus","ru"],
-    "rwanda":["rwnd","rw"],
-    "serbia": [
-        "rs",
-        "sebi",
-        "s\u00e8bi",
-        "\u1230\u122d\u1262\u12eb",
-        "\u1230\u122d\u1265\u12eb",
-        "\uaba2\uab98\uabbf",
-        "\u179f\u17c2\u1794",
-        "\u30bb\u30eb\u30d3\u30a2",
-        "\u585e\u5c14\u7ef4\u4e9a",
-        "\u585e\u723e\u7dad\u4e9e",
-        "\uc138\ub974\ube44\uc544"
-    ],
-    "solomon islands": [
-        "sb",
-        "slmn",
-        "\uc194\ub85c\ubaac"
-    ],
-    "seychelles": ["seyc", "sc"],
-    "sierra leone": ["sleo","sl"],
-    "slovakia": ["svk","sk"],
-    "slovenia": ["svn","si"],
-    "south africa": ["safr","za"],
-    "spain":["spn", "esp","es"],
-    "sudan":["suda","sd"],
-    "suriname":["surm","sr"],
-    "swaziland":["szld","sz"],
-    "sweden":["swdn","se"],
-    "singapore": [
-        "sg",
-        "sing",
-        "sin",
-        "\u65b0\u52a0\u5761",
-        "\u661f\u67b6\u5761",
-        "\uc2f1\uac00\ud3ec\ub974",
-        "\uc2f1\uac00\ud3f4"
-    ],
-    "saint kitts and nevis": ["stcn","kn"],
-    "saint helena": [
-        "shel",
-        "hle",
-        "sh"
-    ],
-    "svalbard and jan mayen": [
-        "sj",
-        "\uc2a4\ubc1c\ubc14\ub974"
-    ],
-    "san marino": [
-        "sm",
-        "smar",
-        "sai",
-        "\u8056\u99ac\u529b\u8afe",
-        "\uc0b0\ub9c8\ub9ac\ub178"
-    ],
-    "somalia": [
-        "so",
-        "soma",
-        "\u1231\u121b\u120c",
-        "\u1236\u121b\u120a\u12eb",
-        "\u30bd\u30de\u30ea\u30a2",
-        "\u7d22\u99ac\u5229\u4e9e",
-        "\u7d22\u99ac\u91cc",
-        "\u7d22\u9a6c\u91cc",
-        "\uc18c\ub9d0\ub9ac\uc544"
-    ],
-    "south sudan": [
-        "\u5357\u82cf\u4e39",
-        "\u5357\u8607\u4e39",
-        "\ub0a8\uc218\ub2e8"
-    ],
-    "sao tome and principe": ["stpr","st"],
-    "saudi arabia":["sarb","sa"],
-    "senegal":["seng","sn"],
-    "el salvador": ["elsl", "sv"],
-    "sint maarten": [
-        "sx",
-        "sxm",
-        "\u5723\u9a6c\u4e01\u5c9b"
-    ],
-    "eswatini": [
-        "\u53f2\u74e6\u6fdf\u862d",
-        "\u65af\u5a01\u58eb\u5170"
-    ],
-    "turks and caicos islands": ["tcis","tc"],
-    "tokelau": [],
-    "turkmenistan": ["tkm","tm"],
-    "tuvalu": [
-        "tv",
-        "tuv",
-        "\u0e95\u0ea7\u0eb2\u0ea5",
-        "\u1271\u126b\u1209",
-        "\u1791\u179c\u17b6\u179b",
-        "\u30c4\u30d0\u30eb",
-        "\u5410\u74e6\u9b6f",
-        "\u56fe\u74e6\u5362",
-        "\u5716\u74e6\u76e7",
-        "\ud22c\ubc1c\ub8e8"
-    ],
-    "taiwan": [
-        "tw",
-        "twan",
-        "\u53f0\u7063"
-    ],
-    "tajikistan":["tjk","tj"],
-    "tanzania":["tazn","tz"],
-    "thailand":["thai","th"],
-    "timor-leste":["tmor","tl"],
-    "togo":["togo","tg"],
-    "tonga":["tong","to"],
-    "trinidad and tobago": ["trin","tt"],
-    "tunisia":["tnsa","tn"],
-    "turkey":["trky","tr"],
-    "uganda":["ugan","ug"],
-    "ukraine": [
-        "ua",
-        "ukr",
-        "\u12e9\u12ad\u122c\u1295",
-        "\u4e4c\u514b\u5170",
-        "\u70cf\u514b\u862d"
-    ],
-    "united states minor outlying islands": [],
     "united states": [
         "a.s",
         "abd",
         "abs",
-        "ab\u015f",
+        "abş",
         "acsh",
         "aish",
         "aksh",
@@ -893,56 +1366,73 @@
         "vsa",
         "zda",
         "ps",
-        "\u03b7\u03c0\u03b1",
-        "\u0430\u0438\u0448",
-        "\u0430\u043a\u0448",
-        "\u0430\u043d\u0443",
-        "\u0430\u0446\u0448",
-        "\u0430\u049b\u0448",
-        "\u0438\u043c",
-        "\u0441\u0430\u0434",
-        "\u0441\u0430\u0449",
-        "\u0441\u0448\u0430",
-        "\u05e4\u05bf\u05e9",
-        "\u0d91.\u0da2",
-        "\u10d0\u10e8\u10e8",
-        "\u12e9 \u12a4\u1235",
-        "\u12e9\u12a4\u1235",
-        "\u30a2\u30e1\u30ea\u30ab",
-        "\u7f8e\u56fd",
-        "\u7f8e\u570b",
-        "\ua0b0\ua1e9",
-        "\ubbf8\uad6d"
+        "ηπα",
+        "аиш",
+        "акш",
+        "ану",
+        "ацш",
+        "ақш",
+        "им",
+        "сад",
+        "сащ",
+        "сша",
+        "פֿש",
+        "එ.ජ",
+        "აშშ",
+        "ዩ ኤስ",
+        "ዩኤስ",
+        "アメリカ",
+        "美国",
+        "美國",
+        "ꂰꇩ",
+        "미국"
     ],
-    "uruguay": ["uru","uy"],
-    "uzbekistan": ["uzb","uz"],
-    "saint vincent and the grenadines": ["stvn","vc"],
-    "british virgin islands": [
-        "vg",
-        "bvi",
-        "brvi"
+    "united states minor outlying islands": [],
+    "uruguay": [
+        "uru",
+        "uy"
     ],
-    "kosovo": [],
-    "mayotte": [
-        "yt",
-        "mywt",
-        "\u05de\u05d9\u05d5\u05d8",
-        "\u0db8\u0dba\u0ddc\u0da7",
-        "\u0f58\u0f0b\u0f61\u0f4a",
-        "\u121c\u12ed\u12a6\u1274",
-        "\u1798\u17b6\u1799\u178f",
-        "\u30de\u30e8\u30c3\u30c8",
-        "\u99ac\u7d04\u7279\u5cf6",
-        "\u9a6c\u7ea6\u7279",
-        "\ub9c8\uc694\ud2b8",
-        "\ub9c8\uc694\ud2f0"
+    "uzbekistan": [
+        "uzb",
+        "uz"
     ],
-    "vanuatu": ["vanu","vu"],
-    "venezuela":["venz","ve"],
-    "vietnam":["vtnm","vn"],
-    "wallis and futuna": ["waft","wf"],
-    "yemen":["yem","ye"],
-    "yugoslavia": ["yugo"],
-    "zambia":["zamb","zm"],
-    "zimbabwe": ["zimb","zw"]
+    "vanuatu": [
+        "vanu",
+        "vu"
+    ],
+    "venezuela": [
+        "venz",
+        "ve"
+    ],
+    "vietnam": [
+        "vtnm",
+        "vn"
+    ],
+    "wallis and futuna": [
+        "waft",
+        "wf"
+    ],
+    "western sahara": [
+        "ssah",
+        "eh",
+        "rasd",
+        "西サハラ",
+        "西撒哈拉",
+        "서사하라"
+    ],
+    "yemen": [
+        "yem",
+        "ye"
+    ],
+    "yugoslavia": [
+        "yugo"
+    ],
+    "zambia": [
+        "zamb",
+        "zm"
+    ],
+    "zimbabwe": [
+        "zimb",
+        "zw"
+    ]
 }

--- a/geocoder_module/countries_acronyms.json
+++ b/geocoder_module/countries_acronyms.json
@@ -11,25 +11,36 @@
         "u.k",
         "gb",
         "g.b.",
-        "g.b"
+        "g.b",
+        "grbr"
     ],
-    "antigua and barbuda": [],
+    "afghanistan": ["afgh"],
+    "albania": ["alb"],
+    "antigua and barbuda": ["anti"],
+    "algeria": ["algr"],
+    "andorra": ["ando"],
+    "australia":["astl"],
+    "austria":["aust"],
+    "azerbaijan": ["azr"],
+
     "anguilla": [
         "axa",
+        "angu",
         "\u30a2\u30f3\u30ae\u30e9",
         "\u5b89\u572d\u62c9",
         "\uc575\uadc8\ub77c"
     ],
-    "armenia": [],
-    "netherlands antilles": [],
+    "armenia": ["arm"],
     "antarctica": [
         "\u5357\u6781\u6d32",
         "\u5357\u6975",
         "\u5357\u6975\u6d32"
     ],
-    "argentina": [],
+    "argentina": ["arg"],
+    "samoa": ["wsam"],
     "american samoa": [],
     "aruba": [
+        "arb",
         "\u0d05\u0d31\u0d41\u0d2c",
         "\u0d05\u0d31\u0d42\u0d2c",
         "\u0d85\u0dbb\u0db6\u0dcf",
@@ -42,28 +53,43 @@
         "\uc544\ub8e8\ubc14"
     ],
     "aland islands": [],
+    "bahamas": ["bama"],
     "bosnia and herzegovina": [
+        "bih",
         "\u6ce2\u65af\u5c3c\u4e9e",
         "\u6ce2\u9ed1",
         "\ubcf4\uc2a4\ub2c8\uc544"
     ],
-    "barbados": [],
+    "botswana":["bot"],
+    "brazil":["brzl"],
+    "brunei":["brni"],
+    "bulgaria":["bulg"],
+    "barbados": ["brdo"],
+    "burma":["burm"],
+    "burundi":["brnd"],
     "bangladesh": [
+        "bang",
         "\u5b5f\u52a0\u62c9",
         "\u5b5f\u52a0\u62c9\u56fd",
         "\u5b5f\u52a0\u62c9\u570b"
     ],
-    "burkina faso": [],
+    "burkina faso": ["burk"],
     "bahrain": [
+        "bahr",
         "awal",
         "aw\u0101l"
     ],
-    "benin": [],
+    "belarus": ["bys"],
+    "belgium":["belg"],
+    "benin": ["benn"],
     "saint barthelemy": [
         "sbh",
         "\u8056\u5df4\u745f\u7c73"
     ],
+    "bhutan":["bhu"],
+    "bolivia":["bol"],
     "bermuda": [
+        "berm",
         "bda",
         "\u1264\u122d\u1219\u12f3",
         "\u767e\u6155\u5927",
@@ -82,6 +108,7 @@
         "\ubd80\ubca0\uc12c"
     ],
     "belize": [
+        "blz",
         "blyz",
         "\u05d1\u05dc\u05d9\u05d6",
         "\u0628\u0644\u064a\u0632",
@@ -99,7 +126,11 @@
         "\u8c9d\u91cc\u65af",
         "\ubca8\ub9ac\uc988"
     ],
+    "cambodia":["cbda"],
+    "cameroon":["cmrn"],
+    "cape verde":["cavi"],
     "canada": [
+        "can",
         "knda",
         "qndh",
         "\u05e7\u05e0\u05d3\u05d4",
@@ -126,14 +157,20 @@
         "\u624e\u4f0a\u5c14"
     ],
     "central african republic": [
+        "cafr",
         "\u4e2d\u975e"
     ],
+    "chad":["chad"],
+    "chile":["chil"],
+    "china":["chin"],
     "republic of the congo": [
         "\u30b3\u30f3\u30b4",
         "\u521a\u679c",
         "\ucf69\uace0"
     ],
+    "syria":["syr"],
     "switzerland": [
+        "swtz",
         "ch",
         "suis",
         "swys",
@@ -144,7 +181,14 @@
         "\uc2a4\uc704\uc2a4"
     ],
     "cook islands": [],
-    "colombia": [],
+    "colombia": ["col"],
+    "comoros": ["como"],
+    "congo brazzaville": ["conb"],
+    "congo kinshasa":["cod"],
+    "costa rica":["cstr"],
+    "cote d'ivoire":["ivco"],
+    "croatia":["hrv"],
+
     "serbia and montenegro": [
         "cs",
         "scg"
@@ -155,8 +199,9 @@
     "christmas island": [
         "xch"
     ],
-    "cyprus": [],
+    "cyprus": ["cypr"],
     "czechia": [
+        "czec",
         "cz",
         "ceki",
         "ceko",
@@ -178,33 +223,56 @@
         "\uccb4\ucf54"
     ],
     "djibouti": [
+        "dji",
         "jib",
         "\u30b8\u30d6\u30c1\u5e02",
         "\u5409\u5e03\u5730\u5e02",
         "\u5409\u5e03\u63d0\u57ce",
         "\uc9c0\ubd80\ud2f0"
     ],
-    "dominica": [],
+    "denmark":["den"],
+    "dominica": ["domn"],
     "dominican republic": [
+        "domr",
+        "dr",
         "\u591a\u660e\u5c3c\u52a0",
         "\u591a\u7c73\u5c3c\u52a0"
     ],
+    "ecuador":["ecua"],
+    "egypt":["egyp"],
+    "equatorial guinea":["egn"],
+    "eritrea":["eri"],
+    "estonia":["est"],
+    "ethiopia":["eth"],
+
     "western sahara": [
+        "ssah",
         "eh",
         "rasd",
         "\u897f\u30b5\u30cf\u30e9",
         "\u897f\u6492\u54c8\u62c9",
         "\uc11c\uc0ac\ud558\ub77c"
     ],
+    "fiji":["fiji"],
+    "finland":["fin"],
     "falkland islands": [],
     "faroe islands": [
         "\u6cd5\u7f57\u7fa4\u5c9b",
         "\u6cd5\u7f85\u7fa4\u5cf6",
         "\ud398\ub85c\uc81c\ub3c4"
     ],
-    "france": [],
-    "grenada": [],
+    "france": ["fr","fran"],
+    "gabon": ["gabn"],
+    "grenada": ["gren"],
+    "germany": ["ger"],
+    "ghana":["ghan"],
+    "greece":["grc"],
+    "guatemala":["guat"],
+    "guinea": ["gnea"],
+    "guinea bissau":["guib"],
+    "guyana":["guy"],
     "georgia": [
+        "geo",
         "\u0433\u04af\u0440\u0436",
         "\u0e88\u0ec0\u0e88\u0e8d",
         "\u0f47\u0f62\u0f0b\u0f47",
@@ -223,6 +291,7 @@
         "\uac74\uc9c0 \uc12c"
     ],
     "gibraltar": [
+        "gib",
         "\u76f4\u5e03\u7f57\u9640",
         "\u76f4\u5e03\u7f85\u9640",
         "\uc9c0\ube0c\ub864\ud130"
@@ -234,6 +303,7 @@
         "\uadf8\ub9b0\ub79c\ub4dc"
     ],
     "gambia": [
+        "gam",
         "\u130b\u121d\u1262\u12eb",
         "\u17a0\u1782\u1794",
         "\u30ac\u30f3\u30d3\u30a2",
@@ -273,7 +343,9 @@
         "\uad0c"
     ],
     "hong kong": [
+        "hk",
         "hkg",
+        "hoko",
         "\u0939\u0919\u0915\u0919",
         "\u09b9\u0982\u0995\u0982",
         "\u0b39\u0b02\u0b15\u0b02",
@@ -285,6 +357,7 @@
         "hu",
         "mgr",
         "mjr",
+        "hung",
         "\u046b\u0433\u0440\u0438",
         "\u0645\u062c\u0631",
         "\u0721\u0713\u072a",
@@ -294,6 +367,9 @@
         "\u5308\u7259\u5229",
         "\ud5dd\uac00\ub9ac"
     ],
+    "haiti":["hat"],
+    "holy see":["vat"],
+    "honduras":["hond"],
     "ireland": [
         "eire",
         "ie",
@@ -324,12 +400,18 @@
         "iran",
         "\u012br\u0101n"
     ],
+    "iceland": ["icld"],
+    "india": ["imd"],
+    "indonesia":["idsa"],
+    "iraq":["iraq"],
+    "israel":["ire"],
+    "italy":["itly"],
     "jersey": [
         "jer",
         "\u6fa4\u897f\u5cf6",
         "\uc800\uc9c0 \uc12c"
     ],
-    "jamaica": [],
+    "jamaica": ["jam"],
     "japan": [
         "hapo",
         "hap\u00f5",
@@ -339,6 +421,7 @@
         "zap\u0254",
         "jpan",
         "ypn",
+        "jpn",
         "\u044f\u043f\u043e\u043d",
         "\u05d9\u05e4\u05df",
         "\u062c\u067e\u0627\u0646",
@@ -357,10 +440,21 @@
         "\ua3dd\ua02a",
         "\uc77c\ubcf8"
     ],
-    "kyrgyzstan": [],
-    "cayman islands": [],
-    "kazakhstan": [],
+    "jordan":["jord"],
+    "kyrgyzstan": ["kgz"],
+    "cayman islands": ["cayi"],
+    "kazakhstan": ["kaz"],
+    "kenya":["keny"],
+    "kiribati":["kiri"],
+    "north korea": ["prk"],
+    "south korea": ["kor"],
+    "kuwait":["kuwt"],
+    "laos":["laos"],
+    "latvia":["latv"],
+    "lesotho":["les"],
+    "liberia":["libr"],
     "lebanon": [
+        "lebn",
         "liba",
         "lib\u00e1",
         "lbnn",
@@ -372,11 +466,15 @@
         "\ub808\ubc14\ub17c"
     ],
     "saint lucia": [
+        "slca",
         "\u5723\u5362\u897f\u4e9a",
         "\u8056\u9732\u897f\u4e9e"
     ],
-    "sri lanka": [],
+    "sri lanka": ["srl"],
+    "liechtenstein":["lcht"],
+    "lithuania":["lith"],
     "luxembourg": [
+        "lxm",
         "lux",
         "\u76e7\u68ee\u5821\u57ce",
         "\u76e7\u68ee\u5821\u5e02"
@@ -401,7 +499,11 @@
         "\u5229\u6bd4\u4e9e",
         "\ub9ac\ube44\uc544"
     ],
+    "macau":["mac"],
+    "macedonia":["mkd"],
+    "madagascar":["madg"],
     "monaco": [
+        "mon",
         "mcm",
         "\ubaa8\ub098\ucf54"
     ],
@@ -413,7 +515,6 @@
         "sfg",
         "\u5723\u9a6c\u4e01\u5c9b"
     ],
-    "madagascar": [],
     "marshall islands": [],
     "north macedonia": [
         "arym",
@@ -423,6 +524,7 @@
     ],
     "mongolia": [
         "mool",
+        "mong",
         "\u043c\u043e\u043e\u043b",
         "\u30e2\u30f3\u30b4\u30eb",
         "\u8499\u53e4",
@@ -432,8 +534,11 @@
     ],
     "northern mariana islands": [],
     "martinique": [],
-    "montserrat": [],
+    "montserrat": ["mont"],
+    "morocco":["moro"],
+    "mozambique":["moz"],
     "malta": [
+        "mlta",
         "malt",
         "mlth",
         "\u05de\u05dc\u05d8\u05d4",
@@ -442,23 +547,35 @@
         "\u99ac\u8033\u4ed6\u5cf6",
         "\ubab0\ud0c0 \uc12c"
     ],
-    "mauritius": [],
-    "malawi": [],
-    "mexico": [],
+    "maldives":["mldv"],
+    "mali":["mali"],
+    "mauritania":["maur"],
+    "mauritius":["mrts"],
+    "malawi": ["malw"],
+    "mexico": ["mex"],
+    "moldova": ["mld"],
     "malaysia": [
+        "mlas",
         "\u121b\u120c\u12e2\u12eb",
         "\u99ac\u4f86\u897f\u4e9e",
         "\u9a6c\u6765\u897f\u4e9a"
     ],
-    "mozambique": [],
-    "new caledonia": [],
+    "new caledonia": ["ncal"],
     "norfolk island": [
         "nlk",
         "\u8bfa\u798f\u514b\u5c9b",
         "\ub178\ud37d \uc12c"
     ],
-    "nepal": [],
+    "namibia":["namb"],
+    "netherlands":["neth"],
+    "netherlands antilles": ["neta"],
+    "nicaragua":["nic"],
+    "niger":["nir"],
+    "nigeria":["nra"],
+    "norway":["norw"],
+    "nepal": ["nep"],
     "nauru": [
+        "nau",
         "naru",
         "n\u00e1r\u00fa",
         "naru",
@@ -546,26 +663,36 @@
         "\ub2c8\uc6b0\uc5d0"
     ],
     "new zealand": [
+        "nzld",
         "\u65b0\u897f\u5170",
         "\u7d10\u897f\u862d",
         "\ub274\uc9c8\ub79c\ub4dc"
     ],
+    "oman":["oman"],
     "panama": [
+        "pan",
         "pty",
         "\u5df4\u62ff\u99ac\u57ce"
     ],
+    "papua new guinea": ["png"],
+    "paraguay":["para"],
+    "peru":["peru"],
     "french polynesia": [],
-    "philippines": [],
-    "pakistan": [],
+    "philippines": ["phil"],
+    "pitcairn islands": ["pitc"],
+    "poland":["pol"],
+    "pakistan": ["pkst"],
+    "palau":["pala"],
     "saint pierre and miquelon": [],
     "puerto rico": [
         "\u6ce2\u591a\u9ece\u5404"
     ],
-    "portugal": [],
-    "qatar": [],
+    "portugal": ["port"],
+    "qatar": ["qtar"],
     "reunion": [],
     "romania": [
         "ro",
+        "rom",
         "\u122e\u121b\u1295\u12eb",
         "\u122e\u121c\u1292\u12eb",
         "\uab86\uab89\uab92\uabbf",
@@ -574,6 +701,8 @@
         "\u7f85\u99ac\u5c3c\u4e9e",
         "\ub8e8\ub9c8\ub2c8\uc544"
     ],
+    "russia": ["rus"],
+    "rwanda":["rwnd"],
     "serbia": [
         "rs",
         "sebi",
@@ -588,28 +717,43 @@
         "\uc138\ub974\ube44\uc544"
     ],
     "solomon islands": [
+        "slmn",
         "\uc194\ub85c\ubaac"
     ],
-    "seychelles": [],
+    "seychelles": ["seyc"],
+    "sierra leone": ["sleo"],
+    "slovakia": ["svk"],
+    "slovenia": ["svn"],
+    "south africa": ["safr"],
+    "spain":["spn", "esp"],
+    "sudan":["suda"],
+    "suriname":["surm"],
+    "swaziland":["szld"],
+    "sweden":["swdn"],
     "singapore": [
+        "sing",
         "sin",
         "\u65b0\u52a0\u5761",
         "\u661f\u67b6\u5761",
         "\uc2f1\uac00\ud3ec\ub974",
         "\uc2f1\uac00\ud3f4"
     ],
+    "saint kitts and nevis": ["stcn"],
     "saint helena": [
+        "shel",
         "hle"
     ],
     "svalbard and jan mayen": [
         "\uc2a4\ubc1c\ubc14\ub974"
     ],
     "san marino": [
+        "smar",
         "sai",
         "\u8056\u99ac\u529b\u8afe",
         "\uc0b0\ub9c8\ub9ac\ub178"
     ],
     "somalia": [
+        "soma",
         "\u1231\u121b\u120c",
         "\u1236\u121b\u120a\u12eb",
         "\u30bd\u30de\u30ea\u30a2",
@@ -623,8 +767,10 @@
         "\u5357\u8607\u4e39",
         "\ub0a8\uc218\ub2e8"
     ],
-    "sao tome and principe": [],
-    "el salvador": [],
+    "sao tome and principe": ["stpr"],
+    "saudi arabia":["sarb"],
+    "senegal":["seng"],
+    "el salvador": ["elsl"],
     "sint maarten": [
         "sxm",
         "\u5723\u9a6c\u4e01\u5c9b"
@@ -633,10 +779,11 @@
         "\u53f2\u74e6\u6fdf\u862d",
         "\u65af\u5a01\u58eb\u5170"
     ],
-    "turks and caicos islands": [],
+    "turks and caicos islands": ["tcis"],
     "tokelau": [],
-    "turkmenistan": [],
+    "turkmenistan": ["tkm"],
     "tuvalu": [
+        "tuv",
         "\u0e95\u0ea7\u0eb2\u0ea5",
         "\u1271\u126b\u1209",
         "\u1791\u179c\u17b6\u179b",
@@ -647,9 +794,21 @@
         "\ud22c\ubc1c\ub8e8"
     ],
     "taiwan": [
+        "twan",
         "\u53f0\u7063"
     ],
+    "tajikistan":["tjk"],
+    "tanzania":["tazn"],
+    "thailand":["thai"],
+    "timor-leste":["tmor"],
+    "togo":["togo"],
+    "tonga":["tong"],
+    "trinidad and tobago": ["trin"],
+    "tunisia":["tnsa"],
+    "turkey":["trky"],
+    "uganda":["ugan"],
     "ukraine": [
+        "ukr",
         "\u12e9\u12ad\u122c\u1295",
         "\u4e4c\u514b\u5170",
         "\u70cf\u514b\u862d"
@@ -708,11 +867,12 @@
         "\ua0b0\ua1e9",
         "\ubbf8\uad6d"
     ],
-    "uruguay": [],
-    "uzbekistan": [],
-    "saint vincent and the grenadines": [],
+    "uruguay": ["uru"],
+    "uzbekistan": ["uzb"],
+    "saint vincent and the grenadines": ["stvn"],
     "british virgin islands": [
-        "bvi"
+        "bvi",
+        "brvi"
     ],
     "kosovo": [],
     "mayotte": [
@@ -728,6 +888,12 @@
         "\ub9c8\uc694\ud2b8",
         "\ub9c8\uc694\ud2f0"
     ],
-    "south africa": [],
-    "zimbabwe": []
+    "vanuatu": ["vanu"],
+    "venezuela":["venz"],
+    "vietnam":["vtnm"],
+    "wallis and futuna": ["waft"],
+    "yemen":["yem"],
+    "yugoslavia": ["yugo"],
+    "zambia":["zamb"],
+    "zimbabwe": ["zimb"]
 }

--- a/geocoder_module/countries_acronyms.json
+++ b/geocoder_module/countries_acronyms.json
@@ -2,6 +2,7 @@
     "united arab emirates": [
         "oaeh",
         "uae",
+        "ae",
         "\u043e\u0430\u044d",
         "\u963f\u8054\u914b"
     ],
@@ -14,32 +15,35 @@
         "g.b",
         "grbr"
     ],
-    "afghanistan": ["afgh"],
-    "albania": ["alb"],
-    "antigua and barbuda": ["anti"],
-    "algeria": ["algr"],
-    "andorra": ["ando"],
-    "australia":["astl"],
-    "austria":["aust"],
-    "azerbaijan": ["azr"],
-
+    "afghanistan": ["afgh", "af"],
+    "albania": ["alb","al"],
+    "antigua and barbuda": ["anti","ag"],
+    "algeria": ["algr","dz"],
+    "andorra": ["ando","ad"],
+    "australia":["astl", "au"],
+    "austria":["aust", "at"],
+    "azerbaijan": ["azr", "az"],
+    "angola":["ao"],
     "anguilla": [
         "axa",
         "angu",
+        "ai",
         "\u30a2\u30f3\u30ae\u30e9",
         "\u5b89\u572d\u62c9",
         "\uc575\uadc8\ub77c"
     ],
-    "armenia": ["arm"],
+    "armenia": ["arm", "am"],
     "antarctica": [
+        "aq",
         "\u5357\u6781\u6d32",
         "\u5357\u6975",
         "\u5357\u6975\u6d32"
     ],
-    "argentina": ["arg"],
-    "samoa": ["wsam"],
-    "american samoa": [],
+    "argentina": ["arg", "ar"],
+    "samoa": ["wsam","ws"],
+    "american samoa": ["as"],
     "aruba": [
+        "aw",
         "arb",
         "\u0d05\u0d31\u0d41\u0d2c",
         "\u0d05\u0d31\u0d42\u0d2c",
@@ -52,43 +56,47 @@
         "\u963f\u9c81\u5df4",
         "\uc544\ub8e8\ubc14"
     ],
-    "aland islands": [],
-    "bahamas": ["bama"],
+    "aland islands": ["ax"],
+    "bahamas": ["bama", "bs"],
     "bosnia and herzegovina": [
+        "bq",
         "bih",
         "\u6ce2\u65af\u5c3c\u4e9e",
         "\u6ce2\u9ed1",
         "\ubcf4\uc2a4\ub2c8\uc544"
     ],
-    "botswana":["bot"],
-    "brazil":["brzl"],
-    "brunei":["brni"],
-    "bulgaria":["bulg"],
-    "barbados": ["brdo"],
+    "botswana":["bot","bw"],
+    "brazil":["brzl", "br"],
+    "brunei":["brni","bn"],
+    "bulgaria":["bulg", "bg"],
+    "barbados": ["brdo","bb"],
     "burma":["burm"],
-    "burundi":["brnd"],
+    "burundi":["brnd","bi"],
     "bangladesh": [
+        "bd",
         "bang",
         "\u5b5f\u52a0\u62c9",
         "\u5b5f\u52a0\u62c9\u56fd",
         "\u5b5f\u52a0\u62c9\u570b"
     ],
-    "burkina faso": ["burk"],
+    "burkina faso": ["burk","bf"],
     "bahrain": [
+        "bh",
         "bahr",
         "awal",
         "aw\u0101l"
     ],
-    "belarus": ["bys"],
-    "belgium":["belg"],
-    "benin": ["benn"],
+    "belarus": ["bys","by"],
+    "belgium":["belg","be"],
+    "benin": ["benn", "bj"],
     "saint barthelemy": [
         "sbh",
         "\u8056\u5df4\u745f\u7c73"
     ],
-    "bhutan":["bhu"],
-    "bolivia":["bol"],
+    "bhutan":["bhu","bt"],
+    "bolivia":["bol","bo"],
     "bermuda": [
+        "bm",
         "berm",
         "bda",
         "\u1264\u122d\u1219\u12f3",
@@ -97,6 +105,7 @@
         "\ubc84\ubba4\ub2e4"
     ],
     "bouvet island": [
+        "bv",
         "buve",
         "\u10d1\u10e3\u10d5\u10d4",
         "\u30d6\u30fc\u30d9\u5cf6",
@@ -108,6 +117,7 @@
         "\ubd80\ubca0\uc12c"
     ],
     "belize": [
+        "bz"
         "blz",
         "blyz",
         "\u05d1\u05dc\u05d9\u05d6",
@@ -126,10 +136,11 @@
         "\u8c9d\u91cc\u65af",
         "\ubca8\ub9ac\uc988"
     ],
-    "cambodia":["cbda"],
-    "cameroon":["cmrn"],
-    "cape verde":["cavi"],
+    "cambodia":["cbda","kh"],
+    "cameroon":["cmrn","cm"],
+    "cape verde":["cavi","cv"],
     "canada": [
+        "ca",
         "can",
         "knda",
         "qndh",
@@ -143,10 +154,12 @@
         "\uce90\ub098\ub2e4"
     ],
     "cocos islands": [
+        "cc",
         "cck",
         "\u79d1\u79d1\u65af"
     ],
     "democratic republic of the congo": [
+        "cd",
         "rdc",
         "zair",
         "zyyr",
@@ -156,19 +169,20 @@
         "\u30b6\u30a4\u30fc\u30eb",
         "\u624e\u4f0a\u5c14"
     ],
-    "central african republic": [
+    "central african republic": ["cf",
         "cafr",
         "\u4e2d\u975e"
     ],
-    "chad":["chad"],
-    "chile":["chil"],
-    "china":["chin"],
+    "chad":["chad", "td"],
+    "chile":["chil", "cl"],
+    "china":["chin","cn"],
     "republic of the congo": [
+        "cg",
         "\u30b3\u30f3\u30b4",
         "\u521a\u679c",
         "\ucf69\uace0"
     ],
-    "syria":["syr"],
+    "syria":["syr","sy"],
     "switzerland": [
         "swtz",
         "ch",
@@ -185,21 +199,23 @@
     "comoros": ["como"],
     "congo brazzaville": ["conb"],
     "congo kinshasa":["cod"],
-    "costa rica":["cstr"],
-    "cote d'ivoire":["ivco"],
-    "croatia":["hrv"],
+    "costa rica":["cstr", "cr"],
+    "cote d'ivoire":["ivco", "ci"],
+    "croatia":["hrv","hr"],
 
     "serbia and montenegro": [
         "cs",
         "scg"
     ],
     "cuba": [
+        "cu",
         "cuba"
     ],
     "christmas island": [
+        "cx",
         "xch"
     ],
-    "cyprus": ["cypr"],
+    "cyprus": ["cypr", "cy"],
     "czechia": [
         "czec",
         "cz",
@@ -223,6 +239,7 @@
         "\uccb4\ucf54"
     ],
     "djibouti": [
+        "dj",
         "dji",
         "jib",
         "\u30b8\u30d6\u30c1\u5e02",
@@ -230,20 +247,21 @@
         "\u5409\u5e03\u63d0\u57ce",
         "\uc9c0\ubd80\ud2f0"
     ],
-    "denmark":["den"],
-    "dominica": ["domn"],
+    "denmark":["den","dk"],
+    "dominica": ["domn","dm"],
     "dominican republic": [
         "domr",
         "dr",
+        "do",
         "\u591a\u660e\u5c3c\u52a0",
         "\u591a\u7c73\u5c3c\u52a0"
     ],
-    "ecuador":["ecua"],
-    "egypt":["egyp"],
-    "equatorial guinea":["egn"],
-    "eritrea":["eri"],
-    "estonia":["est"],
-    "ethiopia":["eth"],
+    "ecuador":["ecua","ec"],
+    "egypt":["egyp","eg"],
+    "equatorial guinea":["egn","gq"],
+    "eritrea":["eri", "er"],
+    "estonia":["est","ee"],
+    "ethiopia":["eth","et"],
 
     "western sahara": [
         "ssah",
@@ -253,25 +271,27 @@
         "\u897f\u6492\u54c8\u62c9",
         "\uc11c\uc0ac\ud558\ub77c"
     ],
-    "fiji":["fiji"],
-    "finland":["fin"],
-    "falkland islands": [],
+    "fiji":["fiji","fj"],
+    "finland":["fin", "fi"],
+    "falkland islands": ["fk"],
     "faroe islands": [
+        "fo",
         "\u6cd5\u7f57\u7fa4\u5c9b",
         "\u6cd5\u7f85\u7fa4\u5cf6",
         "\ud398\ub85c\uc81c\ub3c4"
     ],
     "france": ["fr","fran"],
-    "gabon": ["gabn"],
-    "grenada": ["gren"],
-    "germany": ["ger"],
-    "ghana":["ghan"],
-    "greece":["grc"],
-    "guatemala":["guat"],
-    "guinea": ["gnea"],
-    "guinea bissau":["guib"],
-    "guyana":["guy"],
+    "gabon": ["gabn","ga"],
+    "grenada": ["gren","gd"],
+    "germany": ["ger", "de"],
+    "ghana":["ghan", "gh"],
+    "greece":["grc","gr"],
+    "guatemala":["guat","gt"],
+    "guinea": ["gnea", "gn"],
+    "guinea bissau":["guib", "gw"],
+    "guyana":["guy", "gy"],
     "georgia": [
+        "ge",
         "geo",
         "\u0433\u04af\u0440\u0436",
         "\u0e88\u0ec0\u0e88\u0e8d",
@@ -286,23 +306,27 @@
         "\uc870\uc9c0\uc544"
     ],
     "guernsey": [
+        "gg",
         "gci",
         "\u6839\u897f\u5c9b",
         "\uac74\uc9c0 \uc12c"
     ],
     "gibraltar": [
+        "gi",
         "gib",
         "\u76f4\u5e03\u7f57\u9640",
         "\u76f4\u5e03\u7f85\u9640",
         "\uc9c0\ube0c\ub864\ud130"
     ],
     "greenland": [
+        "gl",
         "\u683c\u9675\u5170",
         "\u683c\u9675\u862d",
         "\uadf8\ub9b0\ub780\ub4dc",
         "\uadf8\ub9b0\ub79c\ub4dc"
     ],
     "gambia": [
+        "gm",
         "gam",
         "\u130b\u121d\u1262\u12eb",
         "\u17a0\u1782\u1794",
@@ -311,9 +335,10 @@
         "\u7518\u6bd4\u4e9e",
         "\uac10\ube44\uc544"
     ],
-    "guadeloupe": [],
+    "guadeloupe": ["gp"],
     "south georgia and the south sandwich islands": [],
     "guam": [
+        "gu",
         "gum",
         "guam",
         "gu\u00e2m",
@@ -367,9 +392,9 @@
         "\u5308\u7259\u5229",
         "\ud5dd\uac00\ub9ac"
     ],
-    "haiti":["hat"],
-    "holy see":["vat"],
-    "honduras":["hond"],
+    "haiti":["hat", "ht"],
+    "holy see":["vat","va"],
+    "honduras":["hond", "hn"],
     "ireland": [
         "eire",
         "ie",
@@ -381,6 +406,7 @@
         "\uc544\uc77c\ub79c\ub4dc"
     ],
     "isle of man": [
+        "im",
         "iom",
         "man",
         "mann",
@@ -397,22 +423,25 @@
     ],
     "british indian ocean territory": [],
     "iran": [
+        "iq",
         "iran",
         "\u012br\u0101n"
     ],
-    "iceland": ["icld"],
-    "india": ["imd"],
-    "indonesia":["idsa"],
+    "iceland": ["icld", "is"],
+    "india": ["imd", "in"],
+    "indonesia":["idsa","id"],
     "iraq":["iraq"],
-    "israel":["ire"],
-    "italy":["itly"],
+    "israel":["isrl","il"],
+    "italy":["itly","it"],
     "jersey": [
+        "je"
         "jer",
         "\u6fa4\u897f\u5cf6",
         "\uc800\uc9c0 \uc12c"
     ],
-    "jamaica": ["jam"],
+    "jamaica": ["jam","jm"],
     "japan": [
+        "jp"
         "hapo",
         "hap\u00f5",
         "japo",
@@ -440,20 +469,21 @@
         "\ua3dd\ua02a",
         "\uc77c\ubcf8"
     ],
-    "jordan":["jord"],
-    "kyrgyzstan": ["kgz"],
-    "cayman islands": ["cayi"],
-    "kazakhstan": ["kaz"],
-    "kenya":["keny"],
-    "kiribati":["kiri"],
-    "north korea": ["prk"],
-    "south korea": ["kor"],
-    "kuwait":["kuwt"],
-    "laos":["laos"],
-    "latvia":["latv"],
-    "lesotho":["les"],
-    "liberia":["libr"],
+    "jordan":["jord","jo"],
+    "kyrgyzstan": ["kgz","kg"],
+    "cayman islands": ["cayi", "ky"],
+    "kazakhstan": ["kaz","kz"],
+    "kenya":["keny","ke"],
+    "kiribati":["kiri","ki"],
+    "north korea": ["prk","kp"],
+    "south korea": ["kor","kr"],
+    "kuwait":["kuwt","ku"],
+    "laos":["laos","la"],
+    "latvia":["latv","lv"],
+    "lesotho":["les","ls"],
+    "liberia":["libr","lr"],
     "lebanon": [
+        "lb",
         "lebn",
         "liba",
         "lib\u00e1",
@@ -466,14 +496,16 @@
         "\ub808\ubc14\ub17c"
     ],
     "saint lucia": [
+        "lc",
         "slca",
         "\u5723\u5362\u897f\u4e9a",
         "\u8056\u9732\u897f\u4e9e"
     ],
-    "sri lanka": ["srl"],
-    "liechtenstein":["lcht"],
-    "lithuania":["lith"],
+    "sri lanka": ["srl","lk"],
+    "liechtenstein":["lcht","li"],
+    "lithuania":["lith","lt"],
     "luxembourg": [
+        "lu"
         "lxm",
         "lux",
         "\u76e7\u68ee\u5821\u57ce",
@@ -486,6 +518,7 @@
         "lbya",
         "lwb",
         "lyby",
+        "ly",
         "\u043b\u0438\u0432\u0438",
         "\u05dc\u05d5\u05d1",
         "\u0644\u0628\u064a\u0627",
@@ -499,10 +532,11 @@
         "\u5229\u6bd4\u4e9e",
         "\ub9ac\ube44\uc544"
     ],
-    "macau":["mac"],
-    "macedonia":["mkd"],
-    "madagascar":["madg"],
+    "macau":["mac","mo"],
+    "macedonia":["mkd","mk"],
+    "madagascar":["madg","mg"],
     "monaco": [
+        "mc",
         "mon",
         "mcm",
         "\ubaa8\ub098\ucf54"
@@ -512,10 +546,11 @@
         "\u9ed1\u5c71"
     ],
     "saint martin": [
+        "mf",
         "sfg",
         "\u5723\u9a6c\u4e01\u5c9b"
     ],
-    "marshall islands": [],
+    "marshall islands": ["mh"],
     "north macedonia": [
         "arym",
         "mk",
@@ -523,6 +558,7 @@
         "\u5317\u9a6c\u5176\u987f"
     ],
     "mongolia": [
+        "mn",
         "mool",
         "mong",
         "\u043c\u043e\u043e\u043b",
@@ -533,11 +569,12 @@
         "\ubabd\uace8"
     ],
     "northern mariana islands": [],
-    "martinique": [],
-    "montserrat": ["mont"],
-    "morocco":["moro"],
-    "mozambique":["moz"],
+    "martinique": ["mq"],
+    "montserrat": ["mont","ms"],
+    "morocco":["moro","ma"],
+    "mozambique":["moz","mz"],
     "malta": [
+        "mt",
         "mlta",
         "malt",
         "mlth",
@@ -547,34 +584,36 @@
         "\u99ac\u8033\u4ed6\u5cf6",
         "\ubab0\ud0c0 \uc12c"
     ],
-    "maldives":["mldv"],
-    "mali":["mali"],
-    "mauritania":["maur"],
-    "mauritius":["mrts"],
-    "malawi": ["malw"],
-    "mexico": ["mex"],
-    "moldova": ["mld"],
+    "maldives":["mldv","mv"],
+    "mali":["mali","ml"],
+    "mauritania":["maur","mr"],
+    "mauritius":["mrts","mu"],
+    "malawi": ["malw","mw"],
+    "mexico": ["mex","mx"],
+    "moldova": ["mld","md"],
     "malaysia": [
+        "my",
         "mlas",
         "\u121b\u120c\u12e2\u12eb",
         "\u99ac\u4f86\u897f\u4e9e",
         "\u9a6c\u6765\u897f\u4e9a"
     ],
-    "new caledonia": ["ncal"],
+    "new caledonia": ["ncal","nc"],
     "norfolk island": [
         "nlk",
         "\u8bfa\u798f\u514b\u5c9b",
         "\ub178\ud37d \uc12c"
     ],
-    "namibia":["namb"],
-    "netherlands":["neth"],
-    "netherlands antilles": ["neta"],
-    "nicaragua":["nic"],
-    "niger":["nir"],
-    "nigeria":["nra"],
-    "norway":["norw"],
-    "nepal": ["nep"],
+    "namibia":["namb","na"],
+    "netherlands":["neth","nl"],
+    "netherlands antilles": ["neta","an"],
+    "nicaragua":["nic","ni"],
+    "niger":["nir","ne"],
+    "nigeria":["nra","ng"],
+    "norway":["norw","no"],
+    "nepal": ["nep","np"],
     "nauru": [
+        "nr",
         "nau",
         "naru",
         "n\u00e1r\u00fa",
@@ -602,6 +641,7 @@
         "\ub098\uc6b0\ub8e8"
     ],
     "niue": [
+        "nu",
         "iue",
         "nija",
         "nioe",
@@ -663,33 +703,35 @@
         "\ub2c8\uc6b0\uc5d0"
     ],
     "new zealand": [
+        "nz",
         "nzld",
         "\u65b0\u897f\u5170",
         "\u7d10\u897f\u862d",
         "\ub274\uc9c8\ub79c\ub4dc"
     ],
-    "oman":["oman"],
+    "oman":["oman","om"],
     "panama": [
+        "pa",
         "pan",
         "pty",
         "\u5df4\u62ff\u99ac\u57ce"
     ],
-    "papua new guinea": ["png"],
-    "paraguay":["para"],
-    "peru":["peru"],
-    "french polynesia": [],
-    "philippines": ["phil"],
-    "pitcairn islands": ["pitc"],
-    "poland":["pol"],
-    "pakistan": ["pkst"],
-    "palau":["pala"],
-    "saint pierre and miquelon": [],
+    "papua new guinea": ["png","pg"],
+    "paraguay":["para","py"],
+    "peru":["peru","pe"],
+    "french polynesia": ["pf"],
+    "philippines": ["phil","ph"],
+    "pitcairn islands": ["pitc","pn"],
+    "poland":["pol","pl"],
+    "pakistan": ["pkst", "pk"],
+    "palau":["pala","pw"],
+    "saint pierre and miquelon": ["pm"],
     "puerto rico": [
         "\u6ce2\u591a\u9ece\u5404"
     ],
-    "portugal": ["port"],
-    "qatar": ["qtar"],
-    "reunion": [],
+    "portugal": ["port","pt"],
+    "qatar": ["qtar","qa"],
+    "reunion": ["re"],
     "romania": [
         "ro",
         "rom",
@@ -701,8 +743,8 @@
         "\u7f85\u99ac\u5c3c\u4e9e",
         "\ub8e8\ub9c8\ub2c8\uc544"
     ],
-    "russia": ["rus"],
-    "rwanda":["rwnd"],
+    "russia": ["rus","ru"],
+    "rwanda":["rwnd","rw"],
     "serbia": [
         "rs",
         "sebi",
@@ -717,20 +759,22 @@
         "\uc138\ub974\ube44\uc544"
     ],
     "solomon islands": [
+        "sb",
         "slmn",
         "\uc194\ub85c\ubaac"
     ],
-    "seychelles": ["seyc"],
-    "sierra leone": ["sleo"],
-    "slovakia": ["svk"],
-    "slovenia": ["svn"],
-    "south africa": ["safr"],
-    "spain":["spn", "esp"],
-    "sudan":["suda"],
-    "suriname":["surm"],
-    "swaziland":["szld"],
-    "sweden":["swdn"],
+    "seychelles": ["seyc", "sc"],
+    "sierra leone": ["sleo","sl"],
+    "slovakia": ["svk","sk"],
+    "slovenia": ["svn","si"],
+    "south africa": ["safr","za"],
+    "spain":["spn", "esp","es"],
+    "sudan":["suda","sd"],
+    "suriname":["surm","sr"],
+    "swaziland":["szld","sz"],
+    "sweden":["swdn","se"],
     "singapore": [
+        "sg",
         "sing",
         "sin",
         "\u65b0\u52a0\u5761",
@@ -738,21 +782,25 @@
         "\uc2f1\uac00\ud3ec\ub974",
         "\uc2f1\uac00\ud3f4"
     ],
-    "saint kitts and nevis": ["stcn"],
+    "saint kitts and nevis": ["stcn","kn"],
     "saint helena": [
         "shel",
-        "hle"
+        "hle",
+        "sh"
     ],
     "svalbard and jan mayen": [
+        "sj"
         "\uc2a4\ubc1c\ubc14\ub974"
     ],
     "san marino": [
+        "sm",
         "smar",
         "sai",
         "\u8056\u99ac\u529b\u8afe",
         "\uc0b0\ub9c8\ub9ac\ub178"
     ],
     "somalia": [
+        "so",
         "soma",
         "\u1231\u121b\u120c",
         "\u1236\u121b\u120a\u12eb",
@@ -767,11 +815,12 @@
         "\u5357\u8607\u4e39",
         "\ub0a8\uc218\ub2e8"
     ],
-    "sao tome and principe": ["stpr"],
-    "saudi arabia":["sarb"],
-    "senegal":["seng"],
-    "el salvador": ["elsl"],
+    "sao tome and principe": ["stpr","st"],
+    "saudi arabia":["sarb","sa"],
+    "senegal":["seng","sn"],
+    "el salvador": ["elsl", "sv"],
     "sint maarten": [
+        "sx",
         "sxm",
         "\u5723\u9a6c\u4e01\u5c9b"
     ],
@@ -779,10 +828,11 @@
         "\u53f2\u74e6\u6fdf\u862d",
         "\u65af\u5a01\u58eb\u5170"
     ],
-    "turks and caicos islands": ["tcis"],
+    "turks and caicos islands": ["tcis","tc"],
     "tokelau": [],
-    "turkmenistan": ["tkm"],
+    "turkmenistan": ["tkm","tm"],
     "tuvalu": [
+        "tv",
         "tuv",
         "\u0e95\u0ea7\u0eb2\u0ea5",
         "\u1271\u126b\u1209",
@@ -794,20 +844,22 @@
         "\ud22c\ubc1c\ub8e8"
     ],
     "taiwan": [
+        "tw",
         "twan",
         "\u53f0\u7063"
     ],
-    "tajikistan":["tjk"],
-    "tanzania":["tazn"],
-    "thailand":["thai"],
-    "timor-leste":["tmor"],
-    "togo":["togo"],
-    "tonga":["tong"],
-    "trinidad and tobago": ["trin"],
-    "tunisia":["tnsa"],
-    "turkey":["trky"],
-    "uganda":["ugan"],
+    "tajikistan":["tjk","tj"],
+    "tanzania":["tazn","tz"],
+    "thailand":["thai","th"],
+    "timor-leste":["tmor","tl"],
+    "togo":["togo","tg"],
+    "tonga":["tong","to"],
+    "trinidad and tobago": ["trin","tt"],
+    "tunisia":["tnsa","tn"],
+    "turkey":["trky","tr"],
+    "uganda":["ugan","ug"],
     "ukraine": [
+        "ua",
         "ukr",
         "\u12e9\u12ad\u122c\u1295",
         "\u4e4c\u514b\u5170",
@@ -867,15 +919,17 @@
         "\ua0b0\ua1e9",
         "\ubbf8\uad6d"
     ],
-    "uruguay": ["uru"],
-    "uzbekistan": ["uzb"],
-    "saint vincent and the grenadines": ["stvn"],
+    "uruguay": ["uru","uy"],
+    "uzbekistan": ["uzb","uz"],
+    "saint vincent and the grenadines": ["stvn","vc"],
     "british virgin islands": [
+        "vg",
         "bvi",
         "brvi"
     ],
     "kosovo": [],
     "mayotte": [
+        "yt",
         "mywt",
         "\u05de\u05d9\u05d5\u05d8",
         "\u0db8\u0dba\u0ddc\u0da7",
@@ -888,12 +942,12 @@
         "\ub9c8\uc694\ud2b8",
         "\ub9c8\uc694\ud2f0"
     ],
-    "vanuatu": ["vanu"],
-    "venezuela":["venz"],
-    "vietnam":["vtnm"],
-    "wallis and futuna": ["waft"],
-    "yemen":["yem"],
+    "vanuatu": ["vanu","vu"],
+    "venezuela":["venz","ve"],
+    "vietnam":["vtnm","vn"],
+    "wallis and futuna": ["waft","wf"],
+    "yemen":["yem","ye"],
     "yugoslavia": ["yugo"],
-    "zambia":["zamb"],
-    "zimbabwe": ["zimb"]
+    "zambia":["zamb","zm"],
+    "zimbabwe": ["zimb","zw"]
 }

--- a/geocoder_module/countries_acronyms.json
+++ b/geocoder_module/countries_acronyms.json
@@ -547,13 +547,11 @@
     ],
     "saint martin": [
         "mf",
-        "sfg",
-        "\u5723\u9a6c\u4e01\u5c9b"
+        "sfg"
     ],
     "marshall islands": ["mh"],
     "north macedonia": [
         "arym",
-        "mk",
         "\u5317\u99ac\u5176\u9813",
         "\u5317\u9a6c\u5176\u987f"
     ],
@@ -876,13 +874,10 @@
         "aksh",
         "anu",
         "aqsh",
-        "as",
         "dya",
         "eua",
-        "im",
         "ipa",
         "jav",
-        "sa",
         "sad",
         "sam",
         "shba",

--- a/geocoder_module/countries_acronyms.json
+++ b/geocoder_module/countries_acronyms.json
@@ -117,7 +117,7 @@
         "\ubd80\ubca0\uc12c"
     ],
     "belize": [
-        "bz"
+        "bz",
         "blz",
         "blyz",
         "\u05d1\u05dc\u05d9\u05d6",
@@ -434,14 +434,14 @@
     "israel":["isrl","il"],
     "italy":["itly","it"],
     "jersey": [
-        "je"
+        "je",
         "jer",
         "\u6fa4\u897f\u5cf6",
         "\uc800\uc9c0 \uc12c"
     ],
     "jamaica": ["jam","jm"],
     "japan": [
-        "jp"
+        "jp",
         "hapo",
         "hap\u00f5",
         "japo",
@@ -505,7 +505,7 @@
     "liechtenstein":["lcht","li"],
     "lithuania":["lith","lt"],
     "luxembourg": [
-        "lu"
+        "lu",
         "lxm",
         "lux",
         "\u76e7\u68ee\u5821\u57ce",
@@ -789,7 +789,7 @@
         "sh"
     ],
     "svalbard and jan mayen": [
-        "sj"
+        "sj",
         "\uc2a4\ubc1c\ubc14\ub974"
     ],
     "san marino": [

--- a/geocoder_module/geocoder.py
+++ b/geocoder_module/geocoder.py
@@ -199,7 +199,6 @@ class Geocoder:
         :param country:        string that represents the country where to search
                                the input location (default None)
         """
-        location = self._handle_acronyms(location)
         try:
             url_api = os.environ["PHOTON_SERVER"] + self.config["url_api_endpoint"]
 
@@ -283,6 +282,8 @@ class Geocoder:
         :param country:        string that represents the country where to search
                                the input location (default None)
         """
+        # Check for acronyms
+        location = self._handle_acronyms(location)
         # Check that location is not in blacklist
         if location.lower() in self.config["blacklist"]:
             logging.warning(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ requirements = open("requirements.txt", "r").readlines()
 
 setup(
     name="geocoder_module",
-    version="0.2.3",
+    version="0.2.5",
     description="Geocoder module",
     python_requires=">=3.7.6",
     url="https://github.com/lifebit-ai/nlp-geocode-module/",

--- a/tests/test_get_location.py
+++ b/tests/test_get_location.py
@@ -209,3 +209,23 @@ def test_get_location_blacklist_returns_empty_location():
     for i in geocoder.config["blacklist"]:
         response = geocoder.get_location_info(i)
         assert response == [{}]
+
+
+class TestHandleAcronyms:
+    def test_acronym_is_found_and_normalised(self):
+        response = geocoder._handle_acronyms("UK")
+        assert response == "united kingdom"
+        response = geocoder._handle_acronyms("US")
+        assert response == "united states"
+        response = geocoder._handle_acronyms("Us")
+        assert response == "Us"
+        response = geocoder._handle_acronyms("U.S")
+        assert response == "united states"
+
+    def test_country_location_is_returned_untouched(self):
+        response = geocoder._handle_acronyms("united kingdom")
+        assert response == "united kingdom"
+
+    def test_local_location_is_returned_untouched(self):
+        response = geocoder._handle_acronyms("madrid")
+        assert response == "madrid"

--- a/tests/test_get_location.py
+++ b/tests/test_get_location.py
@@ -211,6 +211,16 @@ def test_get_location_blacklist_returns_empty_location():
 
 
 class TestHandleAcronyms:
+    def test_no_duplicates_in_country_acronyms(self):
+        for key in geocoder.country_acronyms:
+            for acronym in geocoder.country_acronyms[key]:
+                counter = 0
+                for key_two in geocoder.country_acronyms:
+                    if acronym in geocoder.country_acronyms[key_two]:
+                        counter += 1
+                print(acronym)
+                assert counter == 1
+
     def test_acronym_is_found_and_normalised(self):
         response = geocoder._handle_acronyms("UK")
         assert response == "united kingdom"
@@ -220,6 +230,8 @@ class TestHandleAcronyms:
         assert response == "Us"
         response = geocoder._handle_acronyms("U.S")
         assert response == "united states"
+        response = geocoder._handle_acronyms("\u65b0\u52a0\u5761")
+        assert response == "singapore"
 
     def test_country_location_is_returned_untouched(self):
         response = geocoder._handle_acronyms("united kingdom")


### PR DESCRIPTION
## Why

We are having issues dealing with acronyms from locations like `US` and `UK`, leading those the end up as `Us, France` and `Ukraine, Ukraine`. This PR addresses this issue by implementing a simple acronym dictionary that can disambiguate acronyms from countries.

## What
- Adds acronyms dictionary (including some in languages different than English)
- Adds logic to handle acronyms
- Updates tests

## Notes
- This PR request can be a primer for future improvements
- Acronyms for countries will be updated in an iterative manner. If we find a use case for improvement we will add it.
- Acronyms from provinces like NSW and similar will have to be evaluated on a case-by-case basis. 