### PR TITLE
Fix: Adds fixes and tests for country without extent issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ requirements = open("requirements.txt", "r").readlines()
 
 setup(
     name="geocoder_module",
-    version="0.2.7",
+    version="0.2.8",
     description="Geocoder module",
     python_requires=">=3.7.6",
     url="https://github.com/lifebit-ai/nlp-geocode-module/",

--- a/tests/test_get_location.py
+++ b/tests/test_get_location.py
@@ -6,208 +6,314 @@ from geocoder_module.geocoder import Geocoder
 geocoder = Geocoder()
 
 
-@patch("requests.get")
-def test_get_geocoder_info_returns_a_location_when_queried(
-    mock_get,
-):
-    expected_get_geocoder_api_output = {
-        "features": [
-            {
-                "geometry": {
-                    "coordinates": [151.2164539, -33.8548157],
-                    "type": "Point",
+class TestGetGeocoderInfo:
+    @patch("requests.get")
+    def test_returns_a_location_when_queried(
+        self,
+        mock_get,
+    ):
+        expected_get_geocoder_api_output = {
+            "features": [
+                {
+                    "geometry": {
+                        "coordinates": [151.2164539, -33.8548157],
+                        "type": "Point",
+                    },
+                    "type": "Feature",
+                    "properties": {
+                        "osm_id": 5750005,
+                        "osm_type": "R",
+                        "extent": [150.260825, -33.3641481, 151.343898, -34.1732416],
+                        "country": "Australia",
+                        "osm_key": "place",
+                        "countrycode": "AU",
+                        "osm_value": "city",
+                        "name": "Sydney",
+                        "state": "New South Wales",
+                        "type": "city",
+                    },
                 },
-                "type": "Feature",
-                "properties": {
-                    "osm_id": 5750005,
-                    "osm_type": "R",
-                    "extent": [150.260825, -33.3641481, 151.343898, -34.1732416],
-                    "country": "Australia",
-                    "osm_key": "place",
-                    "countrycode": "AU",
-                    "osm_value": "city",
-                    "name": "Sydney",
-                    "state": "New South Wales",
-                    "type": "city",
+                {
+                    "geometry": {
+                        "coordinates": [151.210047, -33.8679574],
+                        "type": "Point",
+                    },
+                    "type": "Feature",
+                    "properties": {
+                        "osm_id": 5729534,
+                        "osm_type": "R",
+                        "extent": [151.1970047, -33.8561096, 151.223011, -33.8797564],
+                        "country": "Australia",
+                        "osm_key": "place",
+                        "city": "Council of the City of Sydney",
+                        "countrycode": "AU",
+                        "osm_value": "suburb",
+                        "postcode": "2000",
+                        "name": "Sydney",
+                        "state": "New South Wales",
+                        "type": "district",
+                    },
                 },
-            },
-            {
-                "geometry": {"coordinates": [151.210047, -33.8679574], "type": "Point"},
-                "type": "Feature",
-                "properties": {
-                    "osm_id": 5729534,
-                    "osm_type": "R",
-                    "extent": [151.1970047, -33.8561096, 151.223011, -33.8797564],
-                    "country": "Australia",
-                    "osm_key": "place",
-                    "city": "Council of the City of Sydney",
-                    "countrycode": "AU",
-                    "osm_value": "suburb",
-                    "postcode": "2000",
-                    "name": "Sydney",
-                    "state": "New South Wales",
-                    "type": "district",
-                },
-            },
-        ]
-    }
-
-    # Generate expected output from both get requests
-    mock_get.return_value.json.return_value = expected_get_geocoder_api_output
-
-    expected_output = [
-        {
-            "bounding_box": expected_get_geocoder_api_output["features"][0][
-                "properties"
-            ]["extent"],
-            "name": expected_get_geocoder_api_output["features"][0]["properties"][
-                "name"
-            ],
-            "country": expected_get_geocoder_api_output["features"][0]["properties"][
-                "country"
-            ],
-            "coordinates": expected_get_geocoder_api_output["features"][0]["geometry"][
-                "coordinates"
-            ],
+            ]
         }
-    ]
-    response = geocoder._get_geocode_info("sydney")
 
-    assert mock_get.called
-    assert response == expected_output
+        # Generate expected output from both get requests
+        mock_get.return_value.json.return_value = expected_get_geocoder_api_output
 
-
-@patch("requests.get")
-def test_get_geonames_info_returns_right_location_when_queried(
-    mock_get,
-):
-    expected_get_geonames_api_output = {
-        "name": "Sydney",
-        "latitude": "-33.86778",
-        "longitude": "151.20844",
-        "country": "Australia",
-        "continent": "Oceania",
-    }
-    # Generate expected output from both get requests
-    mock_get.return_value.json.return_value = expected_get_geonames_api_output
-
-    expected_output = [
-        {
-            "name": "Sydney",
-            "coordinates": ["151.20844", "-33.86778"],
-            "country": "Australia",
-        }
-    ]
-    response = geocoder._get_geonames_info("sydney", "australia")
-
-    assert mock_get.called
-    assert response == expected_output
-
-
-@patch("requests.get")
-def test_get_location_info_returns_right_location_when_found_by_geocoder_and_geonames(
-    mock_get,
-):
-    expected_get_geocoder_api_output = {
-        "features": [
+        expected_output = [
             {
-                "geometry": {
-                    "coordinates": [151.2164539, -33.8548157],
-                    "type": "Point",
-                },
-                "type": "Feature",
-                "properties": {
-                    "osm_id": 5750005,
-                    "osm_type": "R",
-                    "extent": [150.260825, -33.3641481, 151.343898, -34.1732416],
-                    "country": "Australia",
-                    "osm_key": "place",
-                    "countrycode": "AU",
-                    "osm_value": "city",
-                    "name": "Sydney",
-                    "state": "New South Wales",
-                    "type": "city",
-                },
-            },
-        ]
-    }
-    expected_get_geonames_api_output = {
-        "name": "Sydney",
-        "latitude": "-33.86778",
-        "longitude": "151.20844",
-        "country": "Australia",
-        "continent": "Oceania",
-    }
-    # Generate expected output from both get requests
-    mock_get.return_value.json.return_value = "test"
-    mock_get.return_value.json.side_effect = [
-        expected_get_geocoder_api_output,
-        expected_get_geonames_api_output,
-    ]
-    expected_output = [
-        {
-            "bounding_box": expected_get_geocoder_api_output["features"][0][
-                "properties"
-            ]["extent"],
-            "name": expected_get_geocoder_api_output["features"][0]["properties"][
-                "name"
-            ],
-            "country": expected_get_geocoder_api_output["features"][0]["properties"][
-                "country"
-            ],
-            "coordinates": expected_get_geocoder_api_output["features"][0]["geometry"][
-                "coordinates"
-            ],
-        }
-    ]
-    response = geocoder.get_location_info("sydney")
-
-    assert mock_get.called
-    assert response == expected_output
-
-
-@patch("requests.get")
-def test_get_location_info_returns_empty_list_when_location_found_by_geocoder_cant_be_validated_by_geonames(
-    mock_get,
-):
-    expected_get_geocoder_api_output_2 = {
-        "features": [
-            {
-                "geometry": {
-                    "coordinates": [103.54583559171158, 1.3152402],
-                    "type": "Point",
-                },
-                "type": "Feature",
-                "properties": {
-                    "osm_id": 412628254,
-                    "osm_type": "W",
-                    "extent": [103.5425018, 1.320748, 103.5483276, 1.3097538],
-                    "country": "Malaysia",
-                    "osm_key": "place",
-                    "countrycode": "MY",
-                    "osm_value": "island",
-                    "name": "Asia Petroleum Hub",
-                    "type": "locality",
-                },
+                "bounding_box": expected_get_geocoder_api_output["features"][0][
+                    "properties"
+                ]["extent"],
+                "name": expected_get_geocoder_api_output["features"][0]["properties"][
+                    "name"
+                ],
+                "country": expected_get_geocoder_api_output["features"][0][
+                    "properties"
+                ]["country"],
+                "coordinates": expected_get_geocoder_api_output["features"][0][
+                    "geometry"
+                ]["coordinates"],
             }
         ]
-    }
-    expected_get_geonames_api_output_2 = {}
-    # Generate expected output from both get requests
-    mock_get.return_value.json.side_effect = [
-        expected_get_geocoder_api_output_2,
-        expected_get_geonames_api_output_2,
-    ]
-    expected_output = [{}]
-    response = geocoder.get_location_info("asia petroleum hub")
-    assert mock_get.called
-    assert response == expected_output
+        response = geocoder._get_geocode_info("sydney")
+
+        assert mock_get.called
+        assert response == expected_output
+
+    @patch("requests.get")
+    def test_returns_location_when_country_queried_but_result_has_no_extent(
+        self, mock_get
+    ):
+        expected_get_geocoder_api_output = {
+            "features": [
+                {
+                    "geometry": {
+                        "coordinates": [151.2164539, -33.8548157],
+                        "type": "Point",
+                    },
+                    "type": "Feature",
+                    "properties": {
+                        "osm_id": 5750005,
+                        "osm_type": "R",
+                        "country": "Australia",
+                        "osm_key": "place",
+                        "countrycode": "AU",
+                        "osm_value": "country",
+                        "name": "Australia",
+                        "type": "country",
+                    },
+                }
+            ]
+        }
+
+        # Generate expected output from both get requests
+        mock_get.return_value.json.return_value = expected_get_geocoder_api_output
+
+        expected_output = [
+            {
+                "bounding_box": [72.2460938, -9.0882278, 168.2249543, -55.3228175],
+                "name": expected_get_geocoder_api_output["features"][0]["properties"][
+                    "name"
+                ],
+                "country": expected_get_geocoder_api_output["features"][0][
+                    "properties"
+                ]["country"],
+                "coordinates": expected_get_geocoder_api_output["features"][0][
+                    "geometry"
+                ]["coordinates"],
+            }
+        ]
+        response = geocoder._get_geocode_info("Australia")
+
+        assert mock_get.called
+        assert response == expected_output
+
+    @patch("requests.get")
+    def test_returns_right_location_when_country_queried_with_country_field_but_result_has_no_extent(
+        self, mock_get
+    ):
+        expected_get_geocoder_api_output = {
+            "features": [
+                {
+                    "geometry": {
+                        "coordinates": [151.2164539, -33.8548157],
+                        "type": "Point",
+                    },
+                    "type": "Feature",
+                    "properties": {
+                        "osm_id": 5750005,
+                        "osm_type": "R",
+                        "country": "Australia",
+                        "osm_key": "place",
+                        "countrycode": "AU",
+                        "osm_value": "country",
+                        "name": "Australia",
+                        "type": "country",
+                    },
+                }
+            ]
+        }
+
+        # Generate expected output from both get requests
+        mock_get.return_value.json.return_value = expected_get_geocoder_api_output
+
+        expected_output = [
+            {
+                "bounding_box": [72.2460938, -9.0882278, 168.2249543, -55.3228175],
+                "name": expected_get_geocoder_api_output["features"][0]["properties"][
+                    "name"
+                ],
+                "country": expected_get_geocoder_api_output["features"][0][
+                    "properties"
+                ]["country"],
+                "coordinates": expected_get_geocoder_api_output["features"][0][
+                    "geometry"
+                ]["coordinates"],
+            }
+        ]
+        response = geocoder._get_geocode_info("Australia", country="Australia")
+
+        assert mock_get.called
+        assert response == expected_output
 
 
-def test_get_location_blacklist_returns_empty_location():
-    for i in geocoder.config["blacklist"]:
-        response = geocoder.get_location_info(i)
-        assert response == [{}]
+class TestGetGeonames:
+    @patch("requests.get")
+    def test_get_geonames_info_returns_right_location_when_queried(
+        self,
+        mock_get,
+    ):
+        expected_get_geonames_api_output = {
+            "name": "Sydney",
+            "latitude": "-33.86778",
+            "longitude": "151.20844",
+            "country": "Australia",
+            "continent": "Oceania",
+        }
+        # Generate expected output from both get requests
+        mock_get.return_value.json.return_value = expected_get_geonames_api_output
+
+        expected_output = [
+            {
+                "name": "Sydney",
+                "coordinates": ["151.20844", "-33.86778"],
+                "country": "Australia",
+            }
+        ]
+        response = geocoder._get_geonames_info("sydney", "australia")
+
+        assert mock_get.called
+        assert response == expected_output
+
+
+class TestGetLocationInfo:
+    @patch("requests.get")
+    def test_get_location_info_returns_right_location_when_found_by_geocoder_and_geonames(
+        self,
+        mock_get,
+    ):
+        expected_get_geocoder_api_output = {
+            "features": [
+                {
+                    "geometry": {
+                        "coordinates": [151.2164539, -33.8548157],
+                        "type": "Point",
+                    },
+                    "type": "Feature",
+                    "properties": {
+                        "osm_id": 5750005,
+                        "osm_type": "R",
+                        "extent": [150.260825, -33.3641481, 151.343898, -34.1732416],
+                        "country": "Australia",
+                        "osm_key": "place",
+                        "countrycode": "AU",
+                        "osm_value": "city",
+                        "name": "Sydney",
+                        "state": "New South Wales",
+                        "type": "city",
+                    },
+                },
+            ]
+        }
+        expected_get_geonames_api_output = {
+            "name": "Sydney",
+            "latitude": "-33.86778",
+            "longitude": "151.20844",
+            "country": "Australia",
+            "continent": "Oceania",
+        }
+        # Generate expected output from both get requests
+        mock_get.return_value.json.return_value = "test"
+        mock_get.return_value.json.side_effect = [
+            expected_get_geocoder_api_output,
+            expected_get_geonames_api_output,
+        ]
+        expected_output = [
+            {
+                "bounding_box": expected_get_geocoder_api_output["features"][0][
+                    "properties"
+                ]["extent"],
+                "name": expected_get_geocoder_api_output["features"][0]["properties"][
+                    "name"
+                ],
+                "country": expected_get_geocoder_api_output["features"][0][
+                    "properties"
+                ]["country"],
+                "coordinates": expected_get_geocoder_api_output["features"][0][
+                    "geometry"
+                ]["coordinates"],
+            }
+        ]
+        response = geocoder.get_location_info("sydney")
+
+        assert mock_get.called
+        assert response == expected_output
+
+    @patch("requests.get")
+    def test_get_location_info_returns_empty_list_when_location_found_by_geocoder_cant_be_validated_by_geonames(
+        self,
+        mock_get,
+    ):
+        expected_get_geocoder_api_output_2 = {
+            "features": [
+                {
+                    "geometry": {
+                        "coordinates": [103.54583559171158, 1.3152402],
+                        "type": "Point",
+                    },
+                    "type": "Feature",
+                    "properties": {
+                        "osm_id": 412628254,
+                        "osm_type": "W",
+                        "extent": [103.5425018, 1.320748, 103.5483276, 1.3097538],
+                        "country": "Malaysia",
+                        "osm_key": "place",
+                        "countrycode": "MY",
+                        "osm_value": "island",
+                        "name": "Asia Petroleum Hub",
+                        "type": "locality",
+                    },
+                }
+            ]
+        }
+        expected_get_geonames_api_output_2 = {}
+        # Generate expected output from both get requests
+        mock_get.return_value.json.side_effect = [
+            expected_get_geocoder_api_output_2,
+            expected_get_geonames_api_output_2,
+        ]
+        expected_output = [{}]
+        response = geocoder.get_location_info("asia petroleum hub")
+        assert mock_get.called
+        assert response == expected_output
+
+
+class TestBlacklist:
+    def test_get_location_blacklist_returns_empty_location(self):
+        for i in geocoder.config["blacklist"]:
+            response = geocoder.get_location_info(i)
+            assert response == [{}]
 
 
 class TestHandleAcronyms:

--- a/tests/test_get_location.py
+++ b/tests/test_get_location.py
@@ -130,6 +130,41 @@ class TestGetGeocoderInfo:
         assert response == expected_output
 
     @patch("requests.get")
+    def test_returns_empty_location_when_local_location_result_has_no_extent(
+        self, mock_get
+    ):
+        expected_get_geocoder_api_output = {
+            "features": [
+                {
+                    "geometry": {
+                        "coordinates": [151.2164539, -33.8548157],
+                        "type": "Point",
+                    },
+                    "type": "Feature",
+                    "properties": {
+                        "osm_id": 5750005,
+                        "osm_type": "R",
+                        "country": "Australia",
+                        "osm_key": "place",
+                        "countrycode": "AU",
+                        "osm_value": "country",
+                        "name": "Sidney",
+                        "type": "country",
+                    },
+                }
+            ]
+        }
+
+        # Generate expected output from both get requests
+        mock_get.return_value.json.return_value = expected_get_geocoder_api_output
+
+        expected_output = []
+        response = geocoder._get_geocode_info("Sidney")
+
+        assert mock_get.called
+        assert response == expected_output
+
+    @patch("requests.get")
     def test_returns_right_location_when_country_queried_with_country_field_but_result_has_no_extent(
         self, mock_get
     ):


### PR DESCRIPTION
## Why?

- We had an issue with particular country locations obtained from the geocoder service, they lack the `extent` field in the response making the samples-creation fail because they get discarded even if we are going to assign a bounding box to them. This PR changes the logic order so that we can assign a bounding box before discarding those locations.

## What?

- Update logic around missing bounding box
- Update tests

### Anything in particular you'd like to highlight to reviewers?

This should solve the Switzerland issue seen here: https://sentry.io/organizations/lifebit-org/issues/3411642290/?project=6485219&referrer=slack
